### PR TITLE
feat: show improved error message when aseprite command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+
+The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
+
+## WIP (2020-10-xx)
+
+
+### Added
+
+- Changelog file
+
+### Changed
+
+- show better error message when Aseprite command fails
+
+## 1.0.0 (2020-09-03)
+
+Initial release
+
+### Added
+
+- Creates SpriteFrames with Atlas Texture to be used in AnimatedSprites.
+- Separate each Aseprite Tag as its own animation. In case no tags are defined, import everything as default animation.
+- Converts Aseprite frame duration (defined in milliseconds) to Godot's animation FPS. This way you can create your animation with the right timing in Aseprite, and it should work the same way in Godot.
+- Choose to export Aseprite file as single SpriteFrames resource, or separate each layer as its own resource.
+- Filter out layers you don't want in the final animation, using regex.
+- Supports Aseprite animation direction (forward, reverse, ping-pong)

--- a/addons/AsepriteWizard/ASWizardWindow.tscn
+++ b/addons/AsepriteWizard/ASWizardWindow.tscn
@@ -3,7 +3,6 @@
 [ext_resource path="res://addons/AsepriteWizard/first_options_window.gd" type="Script" id=1]
 
 [node name="ASWizardWindow" type="WindowDialog"]
-visible = true
 margin_right = 600.0
 margin_bottom = 600.0
 rect_min_size = Vector2( 600, 600 )

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -8,6 +8,7 @@ enum {
 
 enum {
   SUCCESS,
+  ERR_ASEPRITE_CMD_NOT_FOUND,
   ERR_SOURCE_FILE_NOT_FOUND,
   ERR_OUTPUT_FOLDER_NOT_FOUND,
   ERR_ASEPRITE_EXPORT_FAILED,
@@ -177,6 +178,9 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
   return exception_layers
 
 func create_resource(source_file: String, output_folder: String, options = {}) -> int:
+  if not _is_aseprite_command_valid():
+    return ERR_ASEPRITE_CMD_NOT_FOUND
+
   var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
 
   var dir = Directory.new()
@@ -312,3 +316,8 @@ func _create_atlastexture_from_frame(image, frame_data):
     atlas.atlas = texture
   atlas.region = Rect2(frame.x, frame.y, frame.w, frame.h)
   return atlas
+
+func _is_aseprite_command_valid():
+  var exit_code = OS.execute(_aseprite_command(), ['--version'], true)
+  return exit_code == 0
+

--- a/addons/AsepriteWizard/first_options_window.gd
+++ b/addons/AsepriteWizard/first_options_window.gd
@@ -137,6 +137,8 @@ func _on_config_button_up():
 
 func _show_error(code: int):
   match code:
+    aseprite.ERR_ASEPRITE_CMD_NOT_FOUND:
+      _show_error_message('Aseprite command failed. Please, check if the right command is in your PATH or configured through the "configuration" button.')
     aseprite.ERR_SOURCE_FILE_NOT_FOUND:
       _show_error_message('source file does not exist')
     aseprite.ERR_OUTPUT_FOLDER_NOT_FOUND:


### PR DESCRIPTION
The current error message thrown when Aseprite command fails is too vague.

Most of the time, the issue happens because the wrong command is being used (or not in PATH).

I'm adding an extra check before running the command, so I can provide a more meaningful message.