### PR TITLE
chore: change indents to tabs, to prevent mixed indent issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
 
-## WIP (2020-10-xx)
-
+## 1.0.1 (2020-10-03)
 
 ### Added
 
@@ -14,6 +13,7 @@ The Working in Progress (WIP) section is for changes that are already in master,
 ### Changed
 
 - show better error message when Aseprite command fails
+- replace space indentation by tabs, as people were seing some weird issues with mixed indent errors on instalation.
 
 ## 1.0.0 (2020-09-03)
 

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -2,322 +2,322 @@ tool
 extends Node
 
 enum {
-  FILE_EXPORT_MODE,
-  LAYERS_EXPORT_MODE
+	FILE_EXPORT_MODE,
+	LAYERS_EXPORT_MODE
 }
 
 enum {
-  SUCCESS,
-  ERR_ASEPRITE_CMD_NOT_FOUND,
-  ERR_SOURCE_FILE_NOT_FOUND,
-  ERR_OUTPUT_FOLDER_NOT_FOUND,
-  ERR_ASEPRITE_EXPORT_FAILED,
-  ERR_UNKNOWN_EXPORT_MODE,
-  ERR_NO_VALID_LAYERS_FOUND,
-  ERR_INVALID_ASEPRITE_SPRITESHEET
+	SUCCESS,
+	ERR_ASEPRITE_CMD_NOT_FOUND,
+	ERR_SOURCE_FILE_NOT_FOUND,
+	ERR_OUTPUT_FOLDER_NOT_FOUND,
+	ERR_ASEPRITE_EXPORT_FAILED,
+	ERR_UNKNOWN_EXPORT_MODE,
+	ERR_NO_VALID_LAYERS_FOUND,
+	ERR_INVALID_ASEPRITE_SPRITESHEET
 }
 
 var default_command = 'aseprite'
 var config: ConfigFile
 
 func init(config_file: ConfigFile, default_cmd: String):
-  config = config_file
-  default_command = default_cmd
+	config = config_file
+	default_command = default_cmd
 
 func _aseprite_command() -> String:
-  var command
-  if config.has_section_key('aseprite', 'command'):
-    command = config.get_value('aseprite', 'command')
+	var command
+	if config.has_section_key('aseprite', 'command'):
+		command = config.get_value('aseprite', 'command')
 
-  if not command or command == "":
-    return default_command
-  return command
+	if not command or command == "":
+		return default_command
+	return command
 
 func _aseprite_list_layers(file_name: String, only_visible = false) -> Array:
-  var output = []
-  var arguments = ["-b", "--list-layers", file_name]
+	var output = []
+	var arguments = ["-b", "--list-layers", file_name]
 
-  if not only_visible:
-    arguments.push_front("--all-layers")
+	if not only_visible:
+		arguments.push_front("--all-layers")
 
-  var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
+	var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
 
-  if exit_code != 0:
-    print('aseprite: failed listing layers')
-    print(output)
-    return []
+	if exit_code != 0:
+		print('aseprite: failed listing layers')
+		print(output)
+		return []
 
-  if output.empty():
-    return output
+	if output.empty():
+		return output
 
-  return output[0].split('\n')
+	return output[0].split('\n')
 
 func _aseprite_export_spritesheet(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
-  var exception_pattern = options.get('exception_pattern', "")
-  var only_visible_layers = options.get('only_visible_layers', false)
-  var trim_images = options.get('trim_images', false)
-  var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename')
-  var basename = _get_file_basename(output_name)
-  var output_dir = output_folder.replace("res://", "./")
-  var data_file = "%s/%s.json" % [output_dir, basename]
-  var sprite_sheet = "%s/%s.png" % [output_dir, basename]
-  var output = []
+	var exception_pattern = options.get('exception_pattern', "")
+	var only_visible_layers = options.get('only_visible_layers', false)
+	var trim_images = options.get('trim_images', false)
+	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename')
+	var basename = _get_file_basename(output_name)
+	var output_dir = output_folder.replace("res://", "./")
+	var data_file = "%s/%s.json" % [output_dir, basename]
+	var sprite_sheet = "%s/%s.png" % [output_dir, basename]
+	var output = []
 
-  var arguments = [
-    "-b",
-    "--list-tags",
-    "--data",
-    data_file,
-    "--format",
-    "json-array",
-    "--sheet",
-    sprite_sheet,
-    file_name
-  ]
+	var arguments = [
+		"-b",
+		"--list-tags",
+		"--data",
+		data_file,
+		"--format",
+		"json-array",
+		"--sheet",
+		sprite_sheet,
+		file_name
+	]
 
-  if not only_visible_layers:
-    arguments.push_front("--all-layers")
+	if not only_visible_layers:
+		arguments.push_front("--all-layers")
 
-  if trim_images:
-    arguments.push_front("--trim")
+	if trim_images:
+		arguments.push_front("--trim")
 
-  if exception_pattern != "":
-    _add_ignore_layer_arguments(file_name, arguments, exception_pattern)
+	if exception_pattern != "":
+		_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
 
-  var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
+	var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
 
-  if exit_code != 0:
-    print('aseprite: failed to export spritesheet')
-    print(output)
-    return {}
-  return {
-    'data_file': data_file.replace("./", "res://"),
-    "sprite_sheet": sprite_sheet.replace("./", "res://")
-  }
+	if exit_code != 0:
+		print('aseprite: failed to export spritesheet')
+		print(output)
+		return {}
+	return {
+		'data_file': data_file.replace("./", "res://"),
+		"sprite_sheet": sprite_sheet.replace("./", "res://")
+	}
 
 
 func _aseprite_export_layers_spritesheet(file_name: String, output_folder: String, options: Dictionary) -> Array:
-  var exception_pattern = options.get('exception_pattern', "")
-  var only_visible_layers = options.get('only_visible_layers', false)
-  var basename = _get_file_basename(file_name)
-  var output_dir = output_folder.replace("res://", "./")
+	var exception_pattern = options.get('exception_pattern', "")
+	var only_visible_layers = options.get('only_visible_layers', false)
+	var basename = _get_file_basename(file_name)
+	var output_dir = output_folder.replace("res://", "./")
 
-  var layers = _aseprite_list_layers(file_name, only_visible_layers)
+	var layers = _aseprite_list_layers(file_name, only_visible_layers)
 
-  var exception_regex
+	var exception_regex
 
-  if exception_pattern != "":
-    exception_regex = RegEx.new()
-    if exception_regex.compile(exception_pattern) != OK:
-      print('exception regex error')
-      exception_regex = null
+	if exception_pattern != "":
+		exception_regex = RegEx.new()
+		if exception_regex.compile(exception_pattern) != OK:
+			print('exception regex error')
+			exception_regex = null
 
-  var output = []
+	var output = []
 
-  for layer in layers:
-    if layer != "" and (not exception_regex or exception_regex.search(layer) == null):
-      output.push_back(_aseprite_export_layer(file_name, layer, output_dir, options))
+	for layer in layers:
+		if layer != "" and (not exception_regex or exception_regex.search(layer) == null):
+			output.push_back(_aseprite_export_layer(file_name, layer, output_dir, options))
 
-  return output
+	return output
 
 func _aseprite_export_layer(file_name: String, layer_name: String, output_folder: String, options: Dictionary) -> Dictionary:
-  var output_prefix = options.get('output_filename', "")
-  var data_file = "%s/%s%s.json" % [output_folder, output_prefix, layer_name]
-  var sprite_sheet = "%s/%s%s.png" % [output_folder, output_prefix, layer_name]
-  var output = []
+	var output_prefix = options.get('output_filename', "")
+	var data_file = "%s/%s%s.json" % [output_folder, output_prefix, layer_name]
+	var sprite_sheet = "%s/%s%s.png" % [output_folder, output_prefix, layer_name]
+	var output = []
 
-  var arguments = [
-    "-b",
-    "--list-tags",
-    "--layer",
-    layer_name,
-    "--data",
-    data_file,
-    "--format",
-    "json-array",
-    "--sheet",
-    sprite_sheet,
-    file_name
-  ]
+	var arguments = [
+		"-b",
+		"--list-tags",
+		"--layer",
+		layer_name,
+		"--data",
+		data_file,
+		"--format",
+		"json-array",
+		"--sheet",
+		sprite_sheet,
+		file_name
+	]
 
-  if options.get('trim_images', false):
-    arguments.push_front("--trim")
+	if options.get('trim_images', false):
+		arguments.push_front("--trim")
 
-  var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
+	var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
 
-  if exit_code != 0:
-    print('aseprite: failed to export layer spritesheet')
-    print(output)
-    return {}
+	if exit_code != 0:
+		print('aseprite: failed to export layer spritesheet')
+		print(output)
+		return {}
 
-  return {
-    'data_file': data_file.replace("./", "res://"),
-    "sprite_sheet": sprite_sheet.replace("./", "res://")
-  }
+	return {
+		'data_file': data_file.replace("./", "res://"),
+		"sprite_sheet": sprite_sheet.replace("./", "res://")
+	}
 
 func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_pattern: String):
-  var layers = _get_exception_layers(file_name, exception_pattern)
-  if not layers.empty():
-    for l in layers:
-      arguments.push_front(l)
-      arguments.push_front('--ignore-layer')
+	var layers = _get_exception_layers(file_name, exception_pattern)
+	if not layers.empty():
+		for l in layers:
+			arguments.push_front(l)
+			arguments.push_front('--ignore-layer')
 
 func _get_exception_layers(file_name: String, exception_pattern: String) -> Array:
-  var layers = _aseprite_list_layers(file_name)
-  var regex = RegEx.new()
-  if regex.compile(exception_pattern) != OK:
-    print('exception regex error')
-    return []
+	var layers = _aseprite_list_layers(file_name)
+	var regex = RegEx.new()
+	if regex.compile(exception_pattern) != OK:
+		print('exception regex error')
+		return []
 
-  var exception_layers = []
-  for layer in layers:
-    if regex.search(layer) != null:
-      exception_layers.push_back(layer)
-  print('Layers ignored:')
-  print(exception_layers)
-  return exception_layers
+	var exception_layers = []
+	for layer in layers:
+		if regex.search(layer) != null:
+			exception_layers.push_back(layer)
+	print('Layers ignored:')
+	print(exception_layers)
+	return exception_layers
 
 func create_resource(source_file: String, output_folder: String, options = {}) -> int:
-  if not _is_aseprite_command_valid():
-    return ERR_ASEPRITE_CMD_NOT_FOUND
+	if not _is_aseprite_command_valid():
+		return ERR_ASEPRITE_CMD_NOT_FOUND
 
-  var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
+	var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
 
-  var dir = Directory.new()
-  if not dir.file_exists(source_file):
-    return ERR_SOURCE_FILE_NOT_FOUND
+	var dir = Directory.new()
+	if not dir.file_exists(source_file):
+		return ERR_SOURCE_FILE_NOT_FOUND
 
-  if not dir.dir_exists(output_folder):
-    return ERR_OUTPUT_FOLDER_NOT_FOUND
+	if not dir.dir_exists(output_folder):
+		return ERR_OUTPUT_FOLDER_NOT_FOUND
 
-  match export_mode:
-    FILE_EXPORT_MODE:
-      return create_sprite_frames_from_aseprite_file(source_file, output_folder, options)
-    LAYERS_EXPORT_MODE:
-      return create_sprite_frames_from_aseprite_layers(source_file, output_folder, options)
-    _:
-      return ERR_UNKNOWN_EXPORT_MODE
+	match export_mode:
+		FILE_EXPORT_MODE:
+			return create_sprite_frames_from_aseprite_file(source_file, output_folder, options)
+		LAYERS_EXPORT_MODE:
+			return create_sprite_frames_from_aseprite_layers(source_file, output_folder, options)
+		_:
+			return ERR_UNKNOWN_EXPORT_MODE
 
 func create_sprite_frames_from_aseprite_file(source_file: String, output_folder: String, options: Dictionary) -> int:
-  var output = _aseprite_export_spritesheet(source_file, output_folder, options)
-  if output.empty():
-    return ERR_ASEPRITE_EXPORT_FAILED
-  return _import(output.data_file)
+	var output = _aseprite_export_spritesheet(source_file, output_folder, options)
+	if output.empty():
+		return ERR_ASEPRITE_EXPORT_FAILED
+	return _import(output.data_file)
 
 func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary) -> int:
-  var output = _aseprite_export_layers_spritesheet(source_file, output_folder, options)
-  if output.empty():
-    return ERR_NO_VALID_LAYERS_FOUND
+	var output = _aseprite_export_layers_spritesheet(source_file, output_folder, options)
+	if output.empty():
+		return ERR_NO_VALID_LAYERS_FOUND
 
-  var result = OK
+	var result = OK
 
-  for o in output:
-    if o.empty():
-      result = ERR_ASEPRITE_EXPORT_FAILED
-    else:
-      result = _import(o.data_file)
+	for o in output:
+		if o.empty():
+			result = ERR_ASEPRITE_EXPORT_FAILED
+		else:
+			result = _import(o.data_file)
 
-  return result
+	return result
 
 func _get_file_basename(file_path: String) -> String:
-  return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
+	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
 
 func _import(source_file) -> int:
-  var file = File.new()
-  var err = file.open(source_file, File.READ)
-  if err != OK:
-      return err
-  var content =  parse_json(file.get_as_text())
+	var file = File.new()
+	var err = file.open(source_file, File.READ)
+	if err != OK:
+			return err
+	var content =  parse_json(file.get_as_text())
 
-  if not _is_valid_aseprite_spritesheet(content):
-    return ERR_INVALID_ASEPRITE_SPRITESHEET
+	if not _is_valid_aseprite_spritesheet(content):
+		return ERR_INVALID_ASEPRITE_SPRITESHEET
 
-  var texture_path = _parse_texture_path(source_file, content)
-  var resource = _create_sprite_frames_with_animations(content, texture_path)
+	var texture_path = _parse_texture_path(source_file, content)
+	var resource = _create_sprite_frames_with_animations(content, texture_path)
 
-  var save_path = "%s.%s" % [source_file.get_basename(), "res"]
-  var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
-  resource.take_over_path(save_path)
-  return code
+	var save_path = "%s.%s" % [source_file.get_basename(), "res"]
+	var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
+	resource.take_over_path(save_path)
+	return code
 
 func _create_sprite_frames_with_animations(content, texture_path):
-  var frames = _get_frames_from_content(content)
-  var sprite_frames = SpriteFrames.new()
-  sprite_frames.remove_animation("default")
+	var frames = _get_frames_from_content(content)
+	var sprite_frames = SpriteFrames.new()
+	sprite_frames.remove_animation("default")
 
-  if content.meta.has("frameTags"):
-    for tag in content.meta.frameTags:
-      var selected_frames = frames.slice(tag.from, tag.to)
-      _add_animation_frames(sprite_frames, tag.name, selected_frames, texture_path, tag.direction)
-  else:
-    _add_animation_frames(sprite_frames, "default", frames, texture_path)
+	if content.meta.has("frameTags"):
+		for tag in content.meta.frameTags:
+			var selected_frames = frames.slice(tag.from, tag.to)
+			_add_animation_frames(sprite_frames, tag.name, selected_frames, texture_path, tag.direction)
+	else:
+		_add_animation_frames(sprite_frames, "default", frames, texture_path)
 
-  return sprite_frames
+	return sprite_frames
 
 func _get_frames_from_content(content):
-  return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
+	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
 
 
 func _add_animation_frames(sprite_frames, animation_name, frames, texture_path, direction = 'forward'):
-    sprite_frames.add_animation(animation_name)
+	sprite_frames.add_animation(animation_name)
 
-    var min_duration = _get_min_duration(frames)
-    var fps = _calculate_fps(min_duration)
+	var min_duration = _get_min_duration(frames)
+	var fps = _calculate_fps(min_duration)
 
-    if direction == 'reverse':
-      frames.invert()
+	if direction == 'reverse':
+		frames.invert()
 
-    for frame in frames:
-      var atlas = _create_atlastexture_from_frame(texture_path, frame)
-      var number_of_sprites = ceil(frame.duration / min_duration)
-      for _i in range(number_of_sprites):
-        sprite_frames.add_frame(animation_name, atlas)
+	for frame in frames:
+		var atlas = _create_atlastexture_from_frame(texture_path, frame)
+		var number_of_sprites = ceil(frame.duration / min_duration)
+		for _i in range(number_of_sprites):
+			sprite_frames.add_frame(animation_name, atlas)
 
-    if direction == 'pingpong':
-      frames.invert()
+	if direction == 'pingpong':
+		frames.invert()
 
-      for frame in frames:
-        var atlas = _create_atlastexture_from_frame(texture_path, frame)
-        var number_of_sprites = ceil(frame.duration / min_duration)
-        for _i in range(number_of_sprites):
-          sprite_frames.add_frame(animation_name, atlas)
+		for frame in frames:
+			var atlas = _create_atlastexture_from_frame(texture_path, frame)
+			var number_of_sprites = ceil(frame.duration / min_duration)
+			for _i in range(number_of_sprites):
+				sprite_frames.add_frame(animation_name, atlas)
 
-    sprite_frames.set_animation_loop(animation_name, true)
-    sprite_frames.set_animation_speed(animation_name, fps)
+	sprite_frames.set_animation_loop(animation_name, true)
+	sprite_frames.set_animation_speed(animation_name, fps)
 
 func _calculate_fps(min_duration: int) -> float:
-  return ceil(1000 / min_duration)
+	return ceil(1000 / min_duration)
 
 func _get_min_duration(frames) -> int:
-  var min_duration = 100000
-  for frame in frames:
-    if frame.duration < min_duration:
-      min_duration = frame.duration
-  return min_duration
+	var min_duration = 100000
+	for frame in frames:
+		if frame.duration < min_duration:
+			min_duration = frame.duration
+	return min_duration
 
 func _parse_texture_path(source_file, content):
-  return "%s/%s" % [source_file.get_base_dir(), content.meta.image]
+	return "%s/%s" % [source_file.get_base_dir(), content.meta.image]
 
 func _is_valid_aseprite_spritesheet(content):
-  return content.has("frames") and content.has("meta") and content.meta.has('image')
+	return content.has("frames") and content.has("meta") and content.meta.has('image')
 
 func _create_atlastexture_from_frame(image, frame_data):
-  var atlas = AtlasTexture.new()
-  var frame = frame_data.frame
+	var atlas = AtlasTexture.new()
+	var frame = frame_data.frame
 
-  if ResourceLoader.has_cached(image):
-    atlas.atlas = ResourceLoader.load(image, 'Image', true)
-    atlas.atlas.take_over_path(image)
-  else:
-    var i = Image.new()
-    i.load(image)
-    var texture = ImageTexture.new()
-    texture.create_from_image(i, 0)
-    atlas.atlas = texture
-  atlas.region = Rect2(frame.x, frame.y, frame.w, frame.h)
-  return atlas
+	if ResourceLoader.has_cached(image):
+		atlas.atlas = ResourceLoader.load(image, 'Image', true)
+		atlas.atlas.take_over_path(image)
+	else:
+		var i = Image.new()
+		i.load(image)
+		var texture = ImageTexture.new()
+		texture.create_from_image(i, 0)
+		atlas.atlas = texture
+	atlas.region = Rect2(frame.x, frame.y, frame.w, frame.h)
+	return atlas
 
 func _is_aseprite_command_valid():
-  var exit_code = OS.execute(_aseprite_command(), ['--version'], true)
-  return exit_code == 0
+	var exit_code = OS.execute(_aseprite_command(), ['--version'], true)
+	return exit_code == 0
 

--- a/addons/AsepriteWizard/config_dialog.gd
+++ b/addons/AsepriteWizard/config_dialog.gd
@@ -4,27 +4,27 @@ extends WindowDialog
 var config: ConfigFile
 
 func _ready():
-  if config.has_section_key('aseprite', 'command'):
-    _aseprite_command_field().text = config.get_value('aseprite', 'command')
-  else:
-    _aseprite_command_field().text = get_default_command()
+	if config.has_section_key('aseprite', 'command'):
+		_aseprite_command_field().text = config.get_value('aseprite', 'command')
+	else:
+		_aseprite_command_field().text = get_default_command()
 
 func init(config_file: ConfigFile):
-  config = config_file
+	config = config_file
 
 func _on_save_button_up():
-  if _aseprite_command_field().text == "":
-    config.set_value('aseprite', 'command', get_default_command())
-  else:
-    config.set_value('aseprite', 'command', _aseprite_command_field().text)
+	if _aseprite_command_field().text == "":
+		config.set_value('aseprite', 'command', get_default_command())
+	else:
+		config.set_value('aseprite', 'command', _aseprite_command_field().text)
 
-  self.hide()
+	self.hide()
 
 func _on_close_button_up():
-  self.hide()
+	self.hide()
 
 static func get_default_command() -> String:
-  return 'aseprite'
+	return 'aseprite'
 
 func _aseprite_command_field() -> LineEdit:
-  return $MarginContainer/VBoxContainer/VBoxContainer/aseprite_command as LineEdit
+	return $MarginContainer/VBoxContainer/VBoxContainer/aseprite_command as LineEdit

--- a/addons/AsepriteWizard/first_options_window.gd
+++ b/addons/AsepriteWizard/first_options_window.gd
@@ -21,167 +21,167 @@ const config_dialog = preload('config_dialog.tscn')
 var aseprite = preload("aseprite_cmd.gd").new()
 
 func _ready():
-  file_dialog_aseprite = _create_aseprite_file_selection()
-  output_folder_dialog = _create_outuput_folder_selection()
-  warning_dialog = AcceptDialog.new()
-  config_window = config_dialog.instance()
-  config_window.init(config)
-  aseprite.init(config, config_window.get_default_command())
+	file_dialog_aseprite = _create_aseprite_file_selection()
+	output_folder_dialog = _create_outuput_folder_selection()
+	warning_dialog = AcceptDialog.new()
+	config_window = config_dialog.instance()
+	config_window.init(config)
+	aseprite.init(config, config_window.get_default_command())
 
-  get_parent().add_child(file_dialog_aseprite)
-  get_parent().add_child(output_folder_dialog)
-  get_parent().add_child(warning_dialog)
-  get_parent().add_child(config_window)
+	get_parent().add_child(file_dialog_aseprite)
+	get_parent().add_child(output_folder_dialog)
+	get_parent().add_child(warning_dialog)
+	get_parent().add_child(config_window)
 
-  _load_persisted_config()
+	_load_persisted_config()
 
 func _exit_tree():
-  file_dialog_aseprite.queue_free()
-  output_folder_dialog.queue_free()
-  warning_dialog.queue_free()
-  config_window.queue_free()
+	file_dialog_aseprite.queue_free()
+	output_folder_dialog.queue_free()
+	warning_dialog.queue_free()
+	config_window.queue_free()
 
 func _load_persisted_config():
-  if config.has_section_key(CONFIG_SECTION_KEY, GROUP_MODE_KEY):
-    _split_mode_field().pressed = config.get_value(CONFIG_SECTION_KEY, GROUP_MODE_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, GROUP_MODE_KEY):
+		_split_mode_field().pressed = config.get_value(CONFIG_SECTION_KEY, GROUP_MODE_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY):
-    _only_visible_layers_field().pressed = config.get_value(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY):
+		_only_visible_layers_field().pressed = config.get_value(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY):
-    _trim_image_field().pressed = config.get_value(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY):
+		_trim_image_field().pressed = config.get_value(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, EXCEPTIONS_KEY):
-    _exception_pattern_field().text = config.get_value(CONFIG_SECTION_KEY, EXCEPTIONS_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, EXCEPTIONS_KEY):
+		_exception_pattern_field().text = config.get_value(CONFIG_SECTION_KEY, EXCEPTIONS_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY):
-    _custom_name_field().text = config.get_value(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY):
+		_custom_name_field().text = config.get_value(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY):
-    _file_location_field().text = config.get_value(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY)
+	if config.has_section_key(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY):
+		_file_location_field().text = config.get_value(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY)
 
-  if config.has_section_key(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY):
-    _output_folder_field().text = config.get_value(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY)
-  else:
-    _output_folder_field().text = 'res://'
+	if config.has_section_key(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY):
+		_output_folder_field().text = config.get_value(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY)
+	else:
+		_output_folder_field().text = 'res://'
 
 func _open_aseprite_file_selection_dialog():
-  var current_selection = _file_location_field().text
-  if current_selection != "":
-    file_dialog_aseprite.current_dir = current_selection.get_base_dir()
-  file_dialog_aseprite.popup_centered_ratio()
+	var current_selection = _file_location_field().text
+	if current_selection != "":
+		file_dialog_aseprite.current_dir = current_selection.get_base_dir()
+	file_dialog_aseprite.popup_centered_ratio()
 
 func _open_output_folder_selection_dialog():
-  var current_selection = _output_folder_field().text
-  if current_selection != "":
-    output_folder_dialog.current_dir = current_selection
-  output_folder_dialog.popup_centered_ratio()
+	var current_selection = _output_folder_field().text
+	if current_selection != "":
+		output_folder_dialog.current_dir = current_selection
+	output_folder_dialog.popup_centered_ratio()
 
 func _create_aseprite_file_selection():
-  var file_dialog = FileDialog.new()
-  file_dialog.mode = FileDialog.MODE_OPEN_FILE
-  file_dialog.access = FileDialog.ACCESS_FILESYSTEM
-  file_dialog.connect("file_selected", self, "_on_aseprite_file_selected")
-  file_dialog.set_filters(PoolStringArray(["*.ase","*.aseprite"]))
-  return file_dialog
+	var file_dialog = FileDialog.new()
+	file_dialog.mode = FileDialog.MODE_OPEN_FILE
+	file_dialog.access = FileDialog.ACCESS_FILESYSTEM
+	file_dialog.connect("file_selected", self, "_on_aseprite_file_selected")
+	file_dialog.set_filters(PoolStringArray(["*.ase","*.aseprite"]))
+	return file_dialog
 
 func _create_outuput_folder_selection():
-  var file_dialog = FileDialog.new()
-  file_dialog.mode = FileDialog.MODE_OPEN_DIR
-  file_dialog.access = FileDialog.ACCESS_RESOURCES
-  file_dialog.connect("dir_selected", self, "_on_output_folder_selected")
-  return file_dialog
+	var file_dialog = FileDialog.new()
+	file_dialog.mode = FileDialog.MODE_OPEN_DIR
+	file_dialog.access = FileDialog.ACCESS_RESOURCES
+	file_dialog.connect("dir_selected", self, "_on_output_folder_selected")
+	return file_dialog
 
 func _on_aseprite_file_selected(path):
-  _file_location_field().text = path
-  config.set_value(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY, path)
+	_file_location_field().text = path
+	config.set_value(CONFIG_SECTION_KEY, LAST_SOURCE_PATH_KEY, path)
 
 func _on_output_folder_selected(path):
-  _output_folder_field().text = path
-  config.set_value(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY, path)
+	_output_folder_field().text = path
+	config.set_value(CONFIG_SECTION_KEY, LAST_OUTPUT_DIR_KEY, path)
 
 func _on_next_btn_up():
-  var aseprite_file = _file_location_field().text
-  var output_location = _output_folder_field().text
-  var split_layers = _split_mode_field().pressed
+	var aseprite_file = _file_location_field().text
+	var output_location = _output_folder_field().text
+	var split_layers = _split_mode_field().pressed
 
-  var export_mode = aseprite.LAYERS_EXPORT_MODE if split_layers else aseprite.FILE_EXPORT_MODE
-  var options = {
-    "export_mode": export_mode,
-    "exception_pattern": _exception_pattern_field().text,
-    "only_visible_layers": _only_visible_layers_field().pressed,
-    "trim_images": _trim_image_field().pressed,
-    "output_filename": _custom_name_field().text
-  }
+	var export_mode = aseprite.LAYERS_EXPORT_MODE if split_layers else aseprite.FILE_EXPORT_MODE
+	var options = {
+		"export_mode": export_mode,
+		"exception_pattern": _exception_pattern_field().text,
+		"only_visible_layers": _only_visible_layers_field().pressed,
+		"trim_images": _trim_image_field().pressed,
+		"output_filename": _custom_name_field().text
+	}
 
-  var exit_code = aseprite.create_resource(aseprite_file, output_location, options)
-  if exit_code != 0:
-    _show_error(exit_code)
-    return
-  _show_import_success_message()
+	var exit_code = aseprite.create_resource(aseprite_file, output_location, options)
+	if exit_code != 0:
+		_show_error(exit_code)
+		return
+	_show_import_success_message()
 
 func _on_close_btn_up():
-  _close_window()
+	_close_window()
 
 func _close_window():
-  config.set_value(CONFIG_SECTION_KEY, GROUP_MODE_KEY, _split_mode_field().pressed)
-  config.set_value(CONFIG_SECTION_KEY, EXCEPTIONS_KEY, _exception_pattern_field().text)
-  config.set_value(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY, _custom_name_field().text)
-  config.set_value(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY, _only_visible_layers_field().pressed)
-  config.set_value(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY, _trim_image_field().pressed)
+	config.set_value(CONFIG_SECTION_KEY, GROUP_MODE_KEY, _split_mode_field().pressed)
+	config.set_value(CONFIG_SECTION_KEY, EXCEPTIONS_KEY, _exception_pattern_field().text)
+	config.set_value(CONFIG_SECTION_KEY, CUSTOM_NAME_KEY, _custom_name_field().text)
+	config.set_value(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY, _only_visible_layers_field().pressed)
+	config.set_value(CONFIG_SECTION_KEY, TRIM_IMAGES_KEY, _trim_image_field().pressed)
 
-  self.hide()
+	self.hide()
 
 func _on_config_button_up():
-  config_window.popup_centered()
+	config_window.popup_centered()
 
 func _show_error(code: int):
-  match code:
-    aseprite.ERR_ASEPRITE_CMD_NOT_FOUND:
-      _show_error_message('Aseprite command failed. Please, check if the right command is in your PATH or configured through the "configuration" button.')
-    aseprite.ERR_SOURCE_FILE_NOT_FOUND:
-      _show_error_message('source file does not exist')
-    aseprite.ERR_OUTPUT_FOLDER_NOT_FOUND:
-      _show_error_message('output location does not exist')
-    aseprite.ERR_ASEPRITE_EXPORT_FAILED:
-      _show_error_message('unable to import file')
-    aseprite.ERR_INVALID_ASEPRITE_SPRITESHEET:
-      _show_error_message('aseprite generated bad data file')
-    aseprite.ERR_NO_VALID_LAYERS_FOUND:
-      _show_error_message('no valid layers found')
-    _:
-      _show_error_message('import failed with code %d' % code)
+	match code:
+		aseprite.ERR_ASEPRITE_CMD_NOT_FOUND:
+			_show_error_message('Aseprite command failed. Please, check if the right command is in your PATH or configured through the "configuration" button.')
+		aseprite.ERR_SOURCE_FILE_NOT_FOUND:
+			_show_error_message('source file does not exist')
+		aseprite.ERR_OUTPUT_FOLDER_NOT_FOUND:
+			_show_error_message('output location does not exist')
+		aseprite.ERR_ASEPRITE_EXPORT_FAILED:
+			_show_error_message('unable to import file')
+		aseprite.ERR_INVALID_ASEPRITE_SPRITESHEET:
+			_show_error_message('aseprite generated bad data file')
+		aseprite.ERR_NO_VALID_LAYERS_FOUND:
+			_show_error_message('no valid layers found')
+		_:
+			_show_error_message('import failed with code %d' % code)
 
 func _show_error_message(message: String):
-  warning_dialog.dialog_text = "Error: %s" % message
-  warning_dialog.popup_centered()
+	warning_dialog.dialog_text = "Error: %s" % message
+	warning_dialog.popup_centered()
 
 func _show_import_success_message():
-  warning_dialog.dialog_text = "Aseprite import succeeded"
-  warning_dialog.popup_centered()
-  warning_dialog.connect("hide", self, "_close_window")
+	warning_dialog.dialog_text = "Aseprite import succeeded"
+	warning_dialog.popup_centered()
+	warning_dialog.connect("hide", self, "_close_window")
 
 
 func _file_location_field() -> LineEdit:
-  return $container/options/file_location/HBoxContainer/file_location_path as LineEdit
+	return $container/options/file_location/HBoxContainer/file_location_path as LineEdit
 
 func _output_folder_field() -> LineEdit:
-  return $container/options/output_folder/HBoxContainer/file_location_path as LineEdit
+	return $container/options/output_folder/HBoxContainer/file_location_path as LineEdit
 
 func _exception_pattern_field() -> LineEdit:
-  return $container/options/exclude_pattern/pattern as LineEdit
+	return $container/options/exclude_pattern/pattern as LineEdit
 
 func _split_mode_field() -> CheckBox:
-  return $container/options/layer_importing_mode/split_layers as CheckBox
+	return $container/options/layer_importing_mode/split_layers as CheckBox
 
 func _only_visible_layers_field() -> CheckBox:
-  return $container/options/layer_importing_mode/visible_layers as CheckBox
+	return $container/options/layer_importing_mode/visible_layers as CheckBox
 
 func _trim_image_field() -> CheckBox:
-  return $container/options/layer_importing_mode/trim_image as CheckBox
+	return $container/options/layer_importing_mode/trim_image as CheckBox
 
 func _custom_name_field() -> LineEdit:
-  return $container/options/custom_filename/pattern as LineEdit
+	return $container/options/custom_filename/pattern as LineEdit
 
 func init(config_file: ConfigFile):
-  config = config_file
+	config = config_file

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Wizard for importing animations from Aseprite as SpriteFrames to be used in AnimatedSprite."
 author="Vinicius Gerevini"
-version="1.0.0"
+version="1.0.1"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -9,28 +9,28 @@ var config: ConfigFile = ConfigFile.new()
 var window: WindowDialog
 
 func _enter_tree():
-  add_tool_menu_item(menu_item_name, self, "_open_window")
-  config = ConfigFile.new()
-  config.load(CONFIG_FILE_PATH)
+	add_tool_menu_item(menu_item_name, self, "_open_window")
+	config = ConfigFile.new()
+	config.load(CONFIG_FILE_PATH)
 
 func _exit_tree():
-  remove_tool_menu_item(menu_item_name)
-  config = null
+	remove_tool_menu_item(menu_item_name)
+	config = null
 
 func _open_window(_ud):
-  window = WizardWindow.instance()
-  window.init(config)
-  _add_to_editor(window)
-  window.popup_centered()
-  window.connect("popup_hide", self, "_on_window_closed")
+	window = WizardWindow.instance()
+	window.init(config)
+	_add_to_editor(window)
+	window.popup_centered()
+	window.connect("popup_hide", self, "_on_window_closed")
 
 func _on_window_closed():
-  if window:
-    window.queue_free()
-    window = null
-    config.save(CONFIG_FILE_PATH)
+	if window:
+		window.queue_free()
+		window = null
+		config.save(CONFIG_FILE_PATH)
 
 func _add_to_editor(element):
-  var editor_interface = get_editor_interface()
-  var base_control = editor_interface.get_base_control()
-  base_control.add_child(element)
+	var editor_interface = get_editor_interface()
+	var base_control = editor_interface.get_base_control()
+	base_control.add_child(element)


### PR DESCRIPTION
As reported on https://github.com/viniciusgerevini/godot-aseprite-wizard/issues/2, some people are seeing mixed indentation issues during instalation. 

To make it less likely to happen, I'm changing this plugin's indentation to tabs, as it's the default used in the Godot editor.