### PR TITLE
Aseprite Import Support

### DIFF
--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -59,27 +59,32 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	
 	var config = ConfigFile.new()
 	config.load(CONFIG_FILE_PATH)
+	aseprite.init(config, 'aseprite')
 	
 	var dir = Directory.new()
 	dir.make_dir(save_path)
 	
-	aseprite.init(config, 'aseprite')
-	
-	print(absolute_source_file)
-	
+	# Clear the directories contents
+	dir.open(save_path)
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	while file_name != "":
+		print(file_name)
+		dir.remove(file_name)
+		file_name = dir.get_next()	
+		
 	var output_filename = '';
 
 	var export_mode = aseprite.LAYERS_EXPORT_MODE if options['split_layers'] else aseprite.FILE_EXPORT_MODE
+
 	var aseprite_opts = {
 		"export_mode": export_mode,
-		"exception_pattern": '',
-		"only_visible_layers": false,
-		"trim_images": false,
+		"exception_pattern": options['exception_pattern'],
+		"only_visible_layers": options['only_visible_layers'],
+		"trim_images": options['trim_images'],
 		"output_filename": output_filename
 	}
-	
-	print(source_path)
-	
+		
 	var exit_code = aseprite.create_resource(absolute_source_file, absolute_save_path, aseprite_opts)
 	if exit_code != 0:
 		print("ERROR - Could not import aseprite file: %s" % get_error_message(exit_code))
@@ -88,9 +93,9 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	dir.open(save_path)
 	dir.list_dir_begin()
 		
-	var file_name = dir.get_next()
+	file_name = dir.get_next()
 	while file_name != "":
-		if file_name.ends_with(".res"):
+		if file_name.ends_with(".res") or file_name.ends_with(".png"):
 			var res = load(save_path + "/" + file_name)
 			ResourceSaver.save(source_path + "/" + file_name, res)
 			

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -45,7 +45,7 @@ func get_preset_name(i):
 
 func get_import_options(i):
 	return [
-		{"name": "split_layers", "default_value": true},
+		{"name": "split_layers", "default_value": false},
 		{"name": "exclude_layers_pattern", "default_value": ''},
 		{"name": "only_visible_layers", "default_value": false},
 		{"name": "trim_images", "default_value": false},

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -35,7 +35,7 @@ func get_save_extension():
 	return "res"
 
 func get_resource_type():
-	return ""
+	return "SpriteFrames"
 
 func get_preset_count():
 	return 1
@@ -46,20 +46,50 @@ func get_preset_name(i):
 func get_import_options(i):
 	return [
 		{"name": "split_layers", "default_value": true},
-		{"name": "exception_pattern", "default_value": ''},
+		{"name": "exclude_layers_pattern", "default_value": ''},
 		{"name": "only_visible_layers", "default_value": false},
 		{"name": "trim_images", "default_value": false},
+		
+		{"name": "sprite_filename_pattern", "default_value": "{basename}.{layer}.{extension}"},
+		
 		{"name": "import_texture_strip", "default_value": false},
-		{"name": "import_sprite_frames", "default_value": true},
+		{"name": "texture_strip_filename_pattern", "default_value": "{basename}.{layer}.Strip.{extension}"},
+		
 		{"name": "import_texture_atlas", "default_value": false},
+		{"name": "texture_atlas_filename_pattern", "default_value": "{basename}.{layer}.Atlas.{extension}"},
+		{"name": "texture_atlas_frame_filename_pattern", "default_value": "{basename}.{layer}.{animation}.{frame}.Atlas.{extension}"},
+		
 		{"name": "import_animated_texture", "default_value": false},
+		{"name": "animated_texture_filename_pattern", "default_value": "{basename}.{layer}.{animation}.Texture.{extension}"},
+		{"name": "animated_texture_frame_filename_pattern", "default_value": "{basename}.{layer}.{animation}.{frame}.Texture.{extension}"},
 		]
+		
+func get_option_visibility(option, options):
+	if option.begins_with("texture_atlas"):
+		return options["import_texture_atlas"]
+		
+	if option.begins_with("animated_texture"):
+		return options["import_animated_texture"]
+		
+	if option.begins_with("texture_strip"):
+		return options["import_texture_strip"]
+	
+	return true
+	
+static func replace_vars(pattern : String, vars : Dictionary):
+	var result = pattern;
+	for k in vars:
+		var v = vars[k]
+		result = result.replace("{%s}" % k, v)
+	return result
 
-func import(source_file, save_path, options, platform_variants, gen_files):		
+func import(source_file, save_path, options, platform_variants, gen_files):			
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
-	
+		
 	var source_path = source_file.substr(0, source_file.find_last('/'))
+	var source_basename = source_file.substr(source_path.length()+1, -1)
+	source_basename = source_basename.substr(0, source_basename.find_last('.'))	
 	
 	var config = ConfigFile.new()
 	config.load(CONFIG_FILE_PATH)
@@ -74,18 +104,16 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	var file_name = dir.get_next()
 	while file_name != "":
 		dir.remove(file_name)
-		file_name = dir.get_next()	
+		file_name = dir.get_next()
 		
-	var output_filename = '';
-
 	var export_mode = aseprite.LAYERS_EXPORT_MODE if options['split_layers'] else aseprite.FILE_EXPORT_MODE
 	
 	var aseprite_opts = {
 		"export_mode": export_mode,
-		"exception_pattern": options['exception_pattern'],
+		"exception_pattern": options['exclude_layers_pattern'],
 		"only_visible_layers": options['only_visible_layers'],
 		"trim_images": options['trim_images'],
-		"output_filename": output_filename
+		"output_filename": ''
 	}
 		
 	var exit_code = aseprite.create_resource(absolute_source_file, absolute_save_path, aseprite_opts)
@@ -97,69 +125,115 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	dir.list_dir_begin()
 		
 	file_name = dir.get_next()
+	
+	var main_sprite_frame_saved = false
+	
+	var global_replacement_vars = {
+		"basename": source_basename,
+	}
+	
+	# Scan through the import directory and process the generated resources based on what options have been selected.
 	while file_name != "":
-		if file_name != ".." and file_name != ".":
-			var path = save_path + "/" + file_name
-				
+		if file_name != ".." and file_name != ".":				
 			if file_name.ends_with(".res"): 
-				var sprite_frames : SpriteFrames = ResourceLoader.load(path, 'SpriteFrames', true)
+				# This is a SpriteFrames resource generated for a layer.
+				var local_replacement_vars = global_replacement_vars.duplicate()
+				local_replacement_vars["layer"] = file_name.substr(0, file_name.length() - 4)
+								
+				if not main_sprite_frame_saved:
+					# Save this resource as the main resource. We need to set something here or Godot won't stop
+					# re-importing the resource. So this is either the SpriteFrames instance of the first layer
+					# (alphabetically) found in the import directory.
+					var sprite_frames : SpriteFrames = ResourceLoader.load("%s/%s" % [save_path, file_name], 'SpriteFrames', true)
+					main_sprite_frame_saved = true
+					var resource_path = "%s.res" % save_path;
+					sprite_frames.take_over_path(resource_path)
+					ResourceSaver.save(resource_path, sprite_frames)
 				
-				if options["import_sprite_frames"]:
-					var res = sprite_frames
-					ResourceSaver.save(source_path + "/" + file_name, res)
+				var sprite_frames : SpriteFrames = ResourceLoader.load("%s/%s" % [save_path, file_name], 'SpriteFrames', true)
 				
+				if options["split_layers"]:
+					var sprite_replacement_vars = local_replacement_vars.duplicate()
+					sprite_replacement_vars["extension"] = "res"
+			
+					var sprite_filename = "%s/%s" % [source_path, replace_vars(options["sprite_filename_pattern"], sprite_replacement_vars)]				
+					ResourceSaver.save(sprite_filename, sprite_frames)
+					sprite_frames.take_over_path(sprite_filename)
+									
 				if options["import_texture_atlas"]:
+					# Create a TextureAtlas resource for this layer.
 					var atlas_texture = null
+					var replacement_vars = local_replacement_vars.duplicate()
+					
 					for anim in sprite_frames.animations:
 						var i=0
+						
+						replacement_vars["animation"] = anim.name
+						replacement_vars["extension"] = "res"
+						
 						for frame in anim.frames:
+							replacement_vars["frame"] = i
+							
 							if not atlas_texture:
 								atlas_texture = (frame as AtlasTexture).atlas
-								var atlas_name = "%s/%sAtlas.tres" % [source_path, file_name.substr(0, file_name.length() - 4)]
-								ResourceSaver.save(atlas_name, atlas_texture)
-								atlas_texture.take_over_path(atlas_name)
+								
+								var atlas_filename = "%s/%s" % [source_path, replace_vars(options["texture_atlas_filename_pattern"], replacement_vars)]
+								ResourceSaver.save(atlas_filename, atlas_texture)
+								atlas_texture.take_over_path(atlas_filename)
 							
 							frame.atlas = atlas_texture
 							
-							var resource_name = "%s/%sAtlas_%s_%s.res" % [source_path, file_name.substr(0, file_name.length() - 4), anim.name, i]
+							var frame_filename = "%s/%s" % [source_path, replace_vars(options["texture_atlas_frame_filename_pattern"], replacement_vars)]
+							ResourceSaver.save(frame_filename, frame)							
 							i+=1
-							ResourceSaver.save(resource_name, frame)
 							
 				if options["import_animated_texture"]:
+					var replacement_vars = local_replacement_vars.duplicate()
+					replacement_vars["extension"] = "res"
 					
 					for anim in sprite_frames.animations:
+						replacement_vars["animation"] = anim.name
+						
 						var tex : AnimatedTexture = AnimatedTexture.new()
 						tex.frames = anim.frames.size()
 						
 						var i=0
 						for frame in anim.frames:
+							replacement_vars["frame"] = i
+							
 							var atlas_tex = frame as AtlasTexture
 							var image : Image = atlas_tex.atlas.get_data()
 							var single_image = Image.new()
 							single_image.create(atlas_tex.get_width(), atlas_tex.get_height(), false, image.get_format())
 							single_image.blit_rect(image, atlas_tex.region, Vector2.ZERO)
 							
-							var resource_name = "%s/%s_%s_%s.res" % [source_path, file_name.substr(0, file_name.length() - 4), anim.name, i]
-							
+							var frame_filename = "%s/%s" % [source_path, replace_vars(options["animated_texture_frame_filename_pattern"], replacement_vars)]
+														
 							var res = ImageTexture.new()
 							res.create_from_image(single_image)
 							res.flags = atlas_tex.flags
-							ResourceSaver.save(resource_name, res)
-							res.take_over_path(resource_name)
+							ResourceSaver.save(frame_filename, res)
+							res.take_over_path(frame_filename)
 							
 							tex.set_frame_texture(i, res)
 							
 							i+=1
 							
-						var resource_name = "%s/%s_%s.res" % [source_path, file_name.substr(0, file_name.length() - 4), anim.name]
-						ResourceSaver.save(resource_name, tex)
+						var texture_filename = "%s/%s" % [source_path, replace_vars(options["animated_texture_filename_pattern"], replacement_vars)]
+						ResourceSaver.save(texture_filename, tex)
 																
 			elif options['import_texture_strip'] and file_name.ends_with(".png"):
-				var img = Image.new()
-				img.load(path)
+				var replacement_vars = global_replacement_vars.duplicate()
+				replacement_vars["layer"] = file_name.substr(0, file_name.length() - 4)
+				replacement_vars["extension"] = "png"
+				
+				var texture_filename = "%s/%s" % [source_path, replace_vars(options["texture_strip_filename_pattern"], replacement_vars)]
+				
+				var img : Image = Image.new()
+				img.load("%s/%s" % [save_path, file_name])
 				var res = ImageTexture.new()
 				res.create_from_image(img)
-				ResourceSaver.save(source_path + "/" + file_name, res)
+				ResourceSaver.save(texture_filename, res)
 				
 		file_name = dir.get_next()
 	return OK

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -1,0 +1,99 @@
+tool
+extends EditorImportPlugin
+
+const CONFIG_FILE_PATH = 'user://aseprite_wizard.cfg'
+
+var aseprite = preload("aseprite_cmd.gd").new()
+
+func get_error_message(code: int):
+	match code:
+		aseprite.ERR_ASEPRITE_CMD_NOT_FOUND:
+			return 'Aseprite command failed. Please, check if the right command is in your PATH or configured through the "configuration" button.'
+		aseprite.ERR_SOURCE_FILE_NOT_FOUND:
+			return 'source file does not exist'
+		aseprite.ERR_OUTPUT_FOLDER_NOT_FOUND:
+			return 'output location does not exist'
+		aseprite.ERR_ASEPRITE_EXPORT_FAILED:
+			return 'unable to import file'
+		aseprite.ERR_INVALID_ASEPRITE_SPRITESHEET:
+			return 'aseprite generated bad data file'
+		aseprite.ERR_NO_VALID_LAYERS_FOUND:
+			return 'no valid layers found'
+		_:
+			return 'import failed with code %d' % code
+
+func get_importer_name():
+	return "aseprite.wizard.plugin"
+
+func get_visible_name():
+	return "Aseprite Importer"
+
+func get_recognized_extensions():
+	return ["aseprite", "ase"]
+
+func get_save_extension():
+	return "res"
+
+func get_resource_type():
+	return ""
+
+func get_preset_count():
+	return 1
+
+func get_preset_name(i):
+	return "Default"
+
+func get_import_options(i):
+	return [
+		{"name": "split_layers", "default_value": true},
+		{"name": "exception_pattern", "default_value": ''},
+		{"name": "only_visible_layers", "default_value": false},
+		{"name": "trim_images", "default_value": false},
+		]
+
+func import(source_file, save_path, options, platform_variants, gen_files):		
+	var absolute_source_file = ProjectSettings.globalize_path(source_file)
+	var absolute_save_path = ProjectSettings.globalize_path(save_path)
+	
+	var source_path = source_file.substr(0, source_file.find_last('/'))
+	
+	var config = ConfigFile.new()
+	config.load(CONFIG_FILE_PATH)
+	
+	var dir = Directory.new()
+	dir.make_dir(save_path)
+	
+	aseprite.init(config, 'aseprite')
+	
+	print(absolute_source_file)
+	
+	var output_filename = '';
+
+	var export_mode = aseprite.LAYERS_EXPORT_MODE if options['split_layers'] else aseprite.FILE_EXPORT_MODE
+	var aseprite_opts = {
+		"export_mode": export_mode,
+		"exception_pattern": '',
+		"only_visible_layers": false,
+		"trim_images": false,
+		"output_filename": output_filename
+	}
+	
+	print(source_path)
+	
+	var exit_code = aseprite.create_resource(absolute_source_file, absolute_save_path, aseprite_opts)
+	if exit_code != 0:
+		print("ERROR - Could not import aseprite file: %s" % get_error_message(exit_code))
+		return FAILED
+		
+	dir.open(save_path)
+	dir.list_dir_begin()
+		
+	var file_name = dir.get_next()
+	while file_name != "":
+		if file_name.ends_with(".res"):
+			var res = load(save_path + "/" + file_name)
+			ResourceSaver.save(source_path + "/" + file_name, res)
+			
+		file_name = dir.get_next()
+		
+	return OK

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -2,19 +2,26 @@ tool
 extends EditorPlugin
 
 const WizardWindow = preload("ASWizardWindow.tscn")
+const ImportPlugin = preload("import_plugin.gd")
 const menu_item_name = "Aseprite Spritesheet Wizard"
 const CONFIG_FILE_PATH = 'user://aseprite_wizard.cfg'
 
 var config: ConfigFile = ConfigFile.new()
 var window: WindowDialog
+var importPlugin : EditorImportPlugin
 
 func _enter_tree():
 	add_tool_menu_item(menu_item_name, self, "_open_window")
+	
 	config = ConfigFile.new()
 	config.load(CONFIG_FILE_PATH)
+	
+	importPlugin = ImportPlugin.new()
+	add_import_plugin(importPlugin)
 
 func _exit_tree():
 	remove_tool_menu_item(menu_item_name)
+	remove_import_plugin(importPlugin)
 	config = null
 
 func _open_window(_ud):


### PR DESCRIPTION
This PR implements a basic import plugin that allows the workflow with aseprite files to be much more straightforward. You still need to set the aseprite binary via the config dialog, everything else can be done by using import settings on the given file directly.

I've implemented different modes to import the sprite data:

- SpriteFrames (default behaviour as used by the plugin) 
- Texture Strips (one single texture file per sprite/layer) 
- Texture Atlases (one AtlasTexture per animation along with textures for each frame)
- Animated textures (one AnimatedTexture per animation)