### PR TITLE
fix importer output location not found on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
 
+## 1.2.1 (2020-12-31)
+
+### Fixed
+
+- Importer was removing output folder on Windows, failing the import.
+- Re-enabling the importer plugin would crash the editor.
+
 ## 1.2.0 (2020-12-24)
 
 ### Added

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -94,7 +94,8 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	dir.list_dir_begin()
 	var file_name = dir.get_next()
 	while file_name != "":
-		dir.remove(file_name)
+		if file_name != '.' and file_name != '..':
+			dir.remove(file_name)
 		file_name = dir.get_next()
 
 	var export_mode = aseprite.LAYERS_EXPORT_MODE if options['split_layers'] else aseprite.FILE_EXPORT_MODE

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Wizard and Importer for working with Aseprite files as SpriteFrames in Godot."
 author="Vinicius Gerevini"
-version="1.2.0"
+version="1.2.1"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -49,6 +49,7 @@ func _on_importer_state_changed():
 		remove_import_plugin(importPlugin)
 		_importer_enabled = false
 	else:
+		importPlugin = ImportPlugin.new()
 		add_import_plugin(importPlugin)
 		_importer_enabled = true
 


### PR DESCRIPTION
closes #9 

I'm not sure why this issue was not affecting Linux as well. Probably concurrency behaves differently on both OS.

Also fixing issue that was crashing Godot on re-enabling importer.