### PR TITLE
fix: resource files are too big

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The Working in Progress (WIP) section is for changes that are already in master,
 ### Fixed
 
 - Resource files generated were bigger than they should be.
-- Sprite sheet path used could lead to silent failure creating `SpriteFrames` with animations but no images.
+- Sprite sheet path used could lead to silent failure creating `SpriteFrames` with animations, but no images.
+- Sprite frame files now are shown in the file system dock as soon as they are created.
+- Fixed warnings caused by image import.
 
 ### Thanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
 
+## 1.2.2 (2021-01-08)
+
+### Fixed
+
+- Resource files generated were bigger than they should be.
+- Sprite sheet path used could lead to silent failure creating `SpriteFrames` with animations but no images.
+
+### Thanks
+
+- Thanks to Lucas Castro (@castroclucas) for identifying the resource size issue and helping me fix it.
+
 ## 1.2.1 (2020-12-31)
 
 ### Fixed
@@ -24,6 +35,9 @@ The Working in Progress (WIP) section is for changes that are already in master,
 - Aseprite Importer. Now `ase` and `aseprite` files can be used seamlessly.
 - Importer with options to also create AtlasTexture, AnimatedTexture and Image strip files.
 
+### Thanks
+
+- Thanks to @aaaaaaaaargh for implementing the importer interface.
 
 ## 1.0.2 (2020-10-26)
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ This plugin uses Aseprite CLI to generate the spritesheet, and then converts it 
 
 It also adds Aseprite importer to Godot, so you can use `*.ase` and `*.aseprite` files directly as resources.
 
-<img align="center" src="./screenshots/import_dock.png" />
-
 <img align="center" src="./screenshots/main_screen.png" />
+
+<img align="center" src="./screenshots/import_dock.png" />
 
 <img align="center" src="./screenshots/aseprite_godot.png" />
 
 ### Features
 
-- Adds Aseprite file importer to Godot.
 - Creates SpriteFrames with Atlas Texture to be used in AnimatedSprites.
 - Separate each Aseprite Tag as its own animation. In case no tags are defined, import everything as default animation.
 - Converts Aseprite frame duration (defined in milliseconds) to Godot's animation FPS. This way you can create your animation with the right timing in Aseprite, and it should work the same way in Godot.
 - Choose to export Aseprite file as single SpriteFrames resource, or separate each layer as its own resource.
 - Filter out layers you don't want in the final animation, using regex.
 - Supports Aseprite animation direction (forward, reverse, ping-pong)
+- Adds Aseprite file importer to Godot (check limitations section).
 - (Importer only) Suppports importing Aseprite files as SpriteFrames, Atlas Texture, Animated Texture and Texture strip.
 
 
@@ -39,15 +39,17 @@ If you are using Windows, a portable version or if the `aseprite` command is not
 
 After activating the plugin, the importer will be enable allowing Aseprite files to be used seamlessly. In addition to that, you can find the wizard screen on `Project -> Tools -> Aseprite Spritesheet Wizard` menu.
 
-### Importer flow
-
-If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project will be automatically imported as a `SpriteFrames` resource, which can be used in `AnimatedSprite` nodes. You can change import settings for each file in the Import dock.
-
 ### Wizard flow
 
 The wizard screen allows you to import files from outside your project root. This can be used in cases where you prefer to not include your Aseprite files to your project, or you don't want them to be imported automatically.
 
 Check this video to see the wizard in action: https://www.youtube.com/watch?v=Yeqlce685E0
+
+### Importer flow
+
+If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project will be automatically imported as a `SpriteFrames` resource, which can be used in `AnimatedSprite` nodes. You can change import settings for each file in the Import dock.
+
+__Note: Currently, files created in the importer are bigger than the ones created through the wizard flow__
 
 ### Options
 
@@ -97,14 +99,10 @@ Godot is using the cached resource. Open another SpriteFrame and then re-open th
 
 This issue will only show outdated resources in the editor. When running the project you will always see the newest changes.
 
+### Files imported by the importer are bigger than the ones imported using the Wizard.
 
-###  Spritesheet file not showing on File Sytem dock (wizard only)
+The sprite sheet file (png) used in the resource is created by Aseprite, outside Godot Editor. Because of that, the plugin needs to trigger a file system scan to import this file.
 
-Changing focus from Godot to another window, and then coming back, will trigger a re-import.
+However, the scan operation is asyncronous and it can't be used in the importer. We implemented a fallback method but, unfortunatelly, it creates bigger resource files.
 
-
-### Warnings in the output related with image file being imported (wizard only)
-
-Those warnings are related on how I import the image file the first time. You'll probably see them when importing the same file twice. It does not affect the process.
-
-
+Until we find an alternative way, the importer will create bigger files. If you prefer to stick with the wizard flow, but you save your aseprite files inside your project folder, there is a configuration to disable the automatic importer.

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -33,6 +33,7 @@ func _aseprite_command() -> String:
 		return default_command
 	return command
 
+
 func _aseprite_list_layers(file_name: String, only_visible = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layers", file_name]
@@ -51,6 +52,7 @@ func _aseprite_list_layers(file_name: String, only_visible = false) -> Array:
 		return output
 
 	return output[0].split('\n')
+
 
 func _aseprite_export_spritesheet(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var exception_pattern = options.get('exception_pattern', "")
@@ -120,6 +122,7 @@ func _aseprite_export_layers_spritesheet(file_name: String, output_folder: Strin
 
 	return output
 
+
 func _aseprite_export_layer(file_name: String, layer_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var output_prefix = options.get('output_filename', "")
 	var data_file = "%s/%s%s.json" % [output_folder, output_prefix, layer_name]
@@ -155,12 +158,14 @@ func _aseprite_export_layer(file_name: String, layer_name: String, output_folder
 		"sprite_sheet": sprite_sheet.replace("./", "res://")
 	}
 
+
 func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_pattern: String):
 	var layers = _get_exception_layers(file_name, exception_pattern)
 	if not layers.empty():
 		for l in layers:
 			arguments.push_front(l)
 			arguments.push_front('--ignore-layer')
+
 
 func _get_exception_layers(file_name: String, exception_pattern: String) -> Array:
 	var layers = _aseprite_list_layers(file_name)
@@ -176,6 +181,7 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
 	print('Layers ignored:')
 	print(exception_layers)
 	return exception_layers
+
 
 func create_resource(source_file: String, output_folder: String, options = {}) -> int:
 	if not _is_aseprite_command_valid():
@@ -198,11 +204,13 @@ func create_resource(source_file: String, output_folder: String, options = {}) -
 		_:
 			return ERR_UNKNOWN_EXPORT_MODE
 
+
 func create_sprite_frames_from_aseprite_file(source_file: String, output_folder: String, options: Dictionary) -> int:
 	var output = _aseprite_export_spritesheet(source_file, output_folder, options)
 	if output.empty():
 		return ERR_ASEPRITE_EXPORT_FAILED
 	return _import(output.data_file)
+
 
 func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary) -> int:
 	var output = _aseprite_export_layers_spritesheet(source_file, output_folder, options)
@@ -219,8 +227,10 @@ func create_sprite_frames_from_aseprite_layers(source_file: String, output_folde
 
 	return result
 
+
 func _get_file_basename(file_path: String) -> String:
 	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
+
 
 func _import(source_file) -> int:
 	var file = File.new()
@@ -232,15 +242,17 @@ func _import(source_file) -> int:
 	if not _is_valid_aseprite_spritesheet(content):
 		return ERR_INVALID_ASEPRITE_SPRITESHEET
 
-	var texture_path = _parse_texture_path(source_file, content)
-	var resource = _create_sprite_frames_with_animations(content, texture_path)
+	var texture = _parse_texture_path(source_file, content)
+
+	var resource = _create_sprite_frames_with_animations(content, texture)
 
 	var save_path = "%s.%s" % [source_file.get_basename(), "res"]
 	var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
 	resource.take_over_path(save_path)
 	return code
 
-func _create_sprite_frames_with_animations(content, texture_path):
+
+func _create_sprite_frames_with_animations(content, texture):
 	var frames = _get_frames_from_content(content)
 	var sprite_frames = SpriteFrames.new()
 	sprite_frames.remove_animation("default")
@@ -248,17 +260,18 @@ func _create_sprite_frames_with_animations(content, texture_path):
 	if content.meta.has("frameTags") and content.meta.frameTags.size() > 0:
 		for tag in content.meta.frameTags:
 			var selected_frames = frames.slice(tag.from, tag.to)
-			_add_animation_frames(sprite_frames, tag.name, selected_frames, texture_path, tag.direction)
+			_add_animation_frames(sprite_frames, tag.name, selected_frames, texture, tag.direction)
 	else:
-		_add_animation_frames(sprite_frames, "default", frames, texture_path)
+		_add_animation_frames(sprite_frames, "default", frames, texture)
 
 	return sprite_frames
+
 
 func _get_frames_from_content(content):
 	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
 
 
-func _add_animation_frames(sprite_frames, animation_name, frames, texture_path, direction = 'forward'):
+func _add_animation_frames(sprite_frames, animation_name, frames, texture, direction = 'forward'):
 	sprite_frames.add_animation(animation_name)
 
 	var min_duration = _get_min_duration(frames)
@@ -268,7 +281,7 @@ func _add_animation_frames(sprite_frames, animation_name, frames, texture_path, 
 		frames.invert()
 
 	for frame in frames:
-		var atlas = _create_atlastexture_from_frame(texture_path, frame)
+		var atlas = _create_atlastexture_from_frame(texture, frame)
 		var number_of_sprites = ceil(frame.duration / min_duration)
 		for _i in range(number_of_sprites):
 			sprite_frames.add_frame(animation_name, atlas)
@@ -277,7 +290,7 @@ func _add_animation_frames(sprite_frames, animation_name, frames, texture_path, 
 		frames.invert()
 
 		for frame in frames:
-			var atlas = _create_atlastexture_from_frame(texture_path, frame)
+			var atlas = _create_atlastexture_from_frame(texture, frame)
 			var number_of_sprites = ceil(frame.duration / min_duration)
 			for _i in range(number_of_sprites):
 				sprite_frames.add_frame(animation_name, atlas)
@@ -296,24 +309,29 @@ func _get_min_duration(frames) -> int:
 	return min_duration
 
 func _parse_texture_path(source_file, content):
-	return "%s/%s" % [source_file.get_base_dir(), content.meta.image]
+	var path = "%s/%s" % [source_file.get_base_dir(), content.meta.image]
+
+	if not ResourceLoader.has_cached(path):
+		# this is a fallback to generate the spritesheet file when it hasn't
+		# been imported before. Files generated in this method are usually
+		# bigger in size than the ones imported by Godot's importer.
+		var image = Image.new()
+		image.load(path)
+		var texture = ImageTexture.new()
+		texture.create_from_image(image)
+		return texture
+
+	return ResourceLoader.load(path, 'Image', true)
+
 
 func _is_valid_aseprite_spritesheet(content):
 	return content.has("frames") and content.has("meta") and content.meta.has('image')
 
+
 func _create_atlastexture_from_frame(image, frame_data):
 	var atlas = AtlasTexture.new()
 	var frame = frame_data.frame
-
-	if ResourceLoader.has_cached(image):
-		atlas.atlas = ResourceLoader.load(image, 'Image', true)
-		atlas.atlas.take_over_path(image)
-	else:
-		var i = Image.new()
-		i.load(image)
-		var texture = ImageTexture.new()
-		texture.create_from_image(i, 0)
-		atlas.atlas = texture
+	atlas.atlas = image
 	atlas.region = Rect2(frame.x, frame.y, frame.w, frame.h)
 	return atlas
 

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -224,7 +224,7 @@ func create_sprite_frames_from_aseprite_file(source_file: String, output_folder:
 	if (_should_check_file_system):
 		yield(_scan_filesystem(), "completed")
 
-	return _import(output.data_file)
+	return _import(output)
 
 
 func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary):
@@ -241,7 +241,7 @@ func create_sprite_frames_from_aseprite_layers(source_file: String, output_folde
 		if o.empty():
 			result = ERR_ASEPRITE_EXPORT_FAILED
 		else:
-			result = _import(o.data_file)
+			result = _import(o)
 
 	return result
 
@@ -250,7 +250,9 @@ func _get_file_basename(file_path: String) -> String:
 	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
 
 
-func _import(source_file) -> int:
+func _import(data) -> int:
+	var source_file = data.data_file
+	var sprite_sheet = data.sprite_sheet
 	var file = File.new()
 	var err = file.open(source_file, File.READ)
 	if err != OK:
@@ -260,7 +262,7 @@ func _import(source_file) -> int:
 	if not _is_valid_aseprite_spritesheet(content):
 		return ERR_INVALID_ASEPRITE_SPRITESHEET
 
-	var texture = _parse_texture_path(source_file, content)
+	var texture = _parse_texture_path(sprite_sheet)
 
 	var resource = _create_sprite_frames_with_animations(content, texture)
 
@@ -326,9 +328,7 @@ func _get_min_duration(frames) -> int:
 			min_duration = frame.duration
 	return min_duration
 
-func _parse_texture_path(source_file, content):
-	var path = "%s/%s" % [source_file.get_base_dir(), content.meta.image]
-
+func _parse_texture_path(path):
 	if not _should_check_file_system and not ResourceLoader.has_cached(path):
 		# this is a fallback for the importer. It generates the spritesheet file when it hasn't
 		# been imported before. Files generated in this method are usually

--- a/addons/AsepriteWizard/first_options_window.gd
+++ b/addons/AsepriteWizard/first_options_window.gd
@@ -117,8 +117,9 @@ func _on_next_btn_up():
 		"trim_images": _trim_image_field().pressed,
 		"output_filename": _custom_name_field().text
 	}
-
-	var exit_code = yield(aseprite.create_resource(aseprite_file, output_location, options), "completed")
+	var exit_code = aseprite.create_resource(aseprite_file, output_location, options)
+	if exit_code is GDScriptFunctionState:
+		exit_code = yield(exit_code, "completed")
 
 	if exit_code != 0:
 		_show_error(exit_code)

--- a/addons/AsepriteWizard/first_options_window.gd
+++ b/addons/AsepriteWizard/first_options_window.gd
@@ -13,6 +13,7 @@ const TRIM_IMAGES_KEY = 'trim_images'
 const CUSTOM_NAME_KEY = 'custom_name'
 
 var config: ConfigFile
+var file_system: EditorFileSystem
 
 var file_dialog_aseprite: FileDialog
 var output_folder_dialog: FileDialog
@@ -29,7 +30,7 @@ func _ready():
 	config_window = config_dialog.instance()
 	config_window.init(config)
 	config_window.connect("importer_state_changed", self, "_notify_importer_state_changed")
-	aseprite.init(config, config_window.get_default_command())
+	aseprite.init(config, config_window.get_default_command(), file_system)
 
 	get_parent().add_child(file_dialog_aseprite)
 	get_parent().add_child(output_folder_dialog)
@@ -117,7 +118,8 @@ func _on_next_btn_up():
 		"output_filename": _custom_name_field().text
 	}
 
-	var exit_code = aseprite.create_resource(aseprite_file, output_location, options)
+	var exit_code = yield(aseprite.create_resource(aseprite_file, output_location, options), "completed")
+
 	if exit_code != 0:
 		_show_error(exit_code)
 		return
@@ -186,8 +188,9 @@ func _trim_image_field() -> CheckBox:
 func _custom_name_field() -> LineEdit:
 	return $container/options/custom_filename/pattern as LineEdit
 
-func init(config_file: ConfigFile):
+func init(config_file: ConfigFile, editor_file_system: EditorFileSystem):
 	config = config_file
+	file_system = editor_file_system
 
 func _notify_importer_state_changed():
 	emit_signal("importer_state_changed")

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -84,6 +84,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 
 	var config = ConfigFile.new()
 	config.load(CONFIG_FILE_PATH)
+
 	aseprite.init(config, 'aseprite')
 
 	var dir = Directory.new()

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Wizard and Importer for working with Aseprite files as SpriteFrames in Godot."
 author="Vinicius Gerevini"
-version="1.2.1"
+version="1.2.2"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -32,7 +32,7 @@ func _exit_tree():
 
 func _open_window(_ud):
 	window = WizardWindow.instance()
-	window.init(config)
+	window.init(config, get_editor_interface().get_resource_filesystem())
 	_add_to_editor(window)
 	window.popup_centered()
 	window.connect("popup_hide", self, "_on_window_closed")


### PR DESCRIPTION
Issue: #13 - Resources files being generated are too big. For instance, an Aseprite file of 6kb was creating a 24mb resource. 

### Root cause:
Each animation frame uses an AtlasTexture with the sprite sheet as source. As the spritesheet is generated outside Godot's editor, it doesn't trigger a scan to import it as a resource, and the workaround was to use an ImageTexture and load the file from the disk.

This texture was supposed to store a reference to the spritesheet, but it seems it is actually embedding the image together, and also duplicating this image for each frame.

### The solution
The main solution programmatically triggers Godot's File System Scan. This is done by using `EditorFileSystem.scan()`.

As this scan is async, to avoid freezing the editor, I had to use a coroutine to wait for the signal:
`yield(file_system, "filesystem_changed")`.
 
The only issue is that to wait for a signal this way, all the parent functions need to return coroutines as well.
 
That's Ok for the wizard screen, but the import plugin needs to be sync and return an exit code. So this solution can't be used there. The workaround for the importer is to keep using the ImageTexture import, but moving it up, doing only once, and not for every frame.

The caveat in this fallback is that the generated file is still bigger than it should be. For comparison, using the main method my test file was 6.5kb, while the fallback method generated a 403kb file.

---





- [x] tested on Linux
- [x] tested on Windows
- [x] tested on MacOS
- [x] tested with more files