### PR TITLE
fix: disable texture filter flags in importer to prevent blurry images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 The Working in Progress (WIP) section is for changes that are already in master, but haven't been published to Godot's asset library yet. Even though the section is called WIP, all changes in master are stable and functional.
 
+## 1.2.3 (2021-02-16)
+
+### Fixed
+
+- Automatic importer was importing images with filters on, generating blurry images.
+
+### Thanks
+
+- Thanks to Ryan Lloyd (@SirRamEsq) for identifying and debugging this issue.
+
 ## 1.2.2 (2021-01-08)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Importer-only options:
 | Animated Texture Frame Filename Pattern | Name for Animated Texture frames files. Default value: `{basename}.{layer}.{animation}.{frame}.Texture.{extension}` |
 
 
-## Limitations
+## Limitations and F.A.Q.
 
 ### Non-looping animations
 
@@ -89,6 +89,14 @@ Loops are useful for running, walking and idle cycles. Single run is useful for 
 ### Import overwrite previous files
 
 Currently, import overwrite previous imported files. Any modification in the previous file will be lost.
+
+
+## Blurry image when using wizard
+
+The wizard screen uses Godot's default image loader. To prevent blurry images, disable the filter flag for Textures in the Import dock and set it as default preset.
+
+For more info, check: https://docs.godotengine.org/en/3.2/getting_started/workflow/assets/import_process.html
+
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Loops are useful for running, walking and idle cycles. Single run is useful for 
 Currently, import overwrite previous imported files. Any modification in the previous file will be lost.
 
 
-## Blurry image when using wizard
+## Blurry images when importing through Wizard Screen
 
 The wizard screen uses Godot's default image loader. To prevent blurry images, disable the filter flag for Textures in the Import dock and set it as default preset.
 

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -336,7 +336,7 @@ func _parse_texture_path(path):
 		var image = Image.new()
 		image.load(path)
 		var texture = ImageTexture.new()
-		texture.create_from_image(image)
+		texture.create_from_image(image, 0)
 		return texture
 
 	return ResourceLoader.load(path, 'Image', true)

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -203,7 +203,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 							var frame_filename = "%s/%s" % [source_path, replace_vars(options["animated_texture/frame_filename_pattern"], replacement_vars)]
 
 							var res = ImageTexture.new()
-							res.create_from_image(single_image)
+							res.create_from_image(single_image, 0)
 							res.flags = atlas_tex.flags
 							ResourceSaver.save(frame_filename, res)
 							res.take_over_path(frame_filename)
@@ -225,7 +225,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 				var img : Image = Image.new()
 				img.load("%s/%s" % [save_path, file_name])
 				var res = ImageTexture.new()
-				res.create_from_image(img)
+				res.create_from_image(img, 0)
 				ResourceSaver.save(texture_filename, res)
 
 		file_name = dir.get_next()

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Wizard and Importer for working with Aseprite files as SpriteFrames in Godot."
 author="Vinicius Gerevini"
-version="1.2.2"
+version="1.2.3"
 script="plugin.gd"


### PR DESCRIPTION
Issue: #17 

This impacts importer only. Wizard Screen uses Godot's default preset.