### PR TITLE
Added support for --ignore-empty and --trim-by-grid CLI options and per-import-type layer masking

### DIFF
--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -63,8 +63,6 @@ func _aseprite_list_layers(file_name: String, only_visible = false) -> Array:
 func _aseprite_export_spritesheet(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
-	var trim_images = options.get('trim_images', false)
-	var trim_by_grid = options.get('trim_by_grid', false)
 	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename')
 	var basename = _get_file_basename(output_name)
 	var output_dir = output_folder.replace("res://", "./")
@@ -87,8 +85,14 @@ func _aseprite_export_spritesheet(file_name: String, output_folder: String, opti
 	if not only_visible_layers:
 		arguments.push_front("--all-layers")
 
-	if trim_images:
+	if options.get('trim_images', false):
 		arguments.push_front("--trim")
+		
+	if options.get('trim_by_grid', false):
+		arguments.push_front('--trim-by-grid')
+		
+	if options.get('ignore_empty', false):
+		arguments.push_front('--ignore-empty')
 
 	if exception_pattern != "":
 		_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
@@ -108,7 +112,6 @@ func _aseprite_export_spritesheet(file_name: String, output_folder: String, opti
 func _aseprite_export_layers_spritesheet(file_name: String, output_folder: String, options: Dictionary) -> Array:
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
-	var basename = _get_file_basename(file_name)
 	var output_dir = output_folder.replace("res://", "./")
 
 	var layers = _aseprite_list_layers(file_name, only_visible_layers)
@@ -352,7 +355,7 @@ func _add_animation_frames(sprite_frames, animation_name, frames, texture, direc
 	sprite_frames.set_animation_speed(animation_name, fps)
 
 func _calculate_fps(min_duration: int) -> float:
-	return ceil(1000 / min_duration)
+	return ceil(1000.0 / min_duration)
 
 func _get_min_duration(frames) -> int:
 	var min_duration = 100000

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -64,6 +64,7 @@ func _aseprite_export_spritesheet(file_name: String, output_folder: String, opti
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
 	var trim_images = options.get('trim_images', false)
+	var trim_by_grid = options.get('trim_by_grid', false)
 	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename')
 	var basename = _get_file_basename(output_name)
 	var output_dir = output_folder.replace("res://", "./")
@@ -151,6 +152,12 @@ func _aseprite_export_layer(file_name: String, layer_name: String, output_folder
 
 	if options.get('trim_images', false):
 		arguments.push_front("--trim")
+		
+	if options.get('trim_by_grid', false):
+		arguments.push_front('--trim-by-grid')
+		
+	if options.get('ignore_empty', false):
+		arguments.push_front('--ignore-empty')
 
 	var exit_code = OS.execute(_aseprite_command(), arguments, true, output, true)
 

--- a/addons/AsepriteWizard/import_plugin.gd
+++ b/addons/AsepriteWizard/import_plugin.gd
@@ -48,7 +48,8 @@ func get_import_options(i):
 		{"name": "split_layers", "default_value": false},
 		{"name": "exclude_layers_pattern", "default_value": ''},
 		{"name": "only_visible_layers", "default_value": false},
-		{"name": "trim_images", "default_value": false},
+		{"name": "ignore_empty_frames", "default_value": true},
+		{"name": "trim_mode", "property_hint": PROPERTY_HINT_ENUM, "default_value": 0, "hint_string": "Disabled,Trim,Trim by grid" },
 
 		{"name": "sprite_filename_pattern", "default_value": "{basename}.{layer}.{extension}"},
 
@@ -105,7 +106,9 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		"export_mode": export_mode,
 		"exception_pattern": options['exclude_layers_pattern'],
 		"only_visible_layers": options['only_visible_layers'],
-		"trim_images": options['trim_images'],
+		"trim_images": options['trim_mode'] == 1,
+		"trim_by_grid": options['trim_mode'] == 2,
+		"ignore_empty": options['ignore_empty_frames'],
 		"output_filename": ''
 	}
 


### PR DESCRIPTION
Hey, great to see you're still working on this awesome plugin! Still using it here as well and I thought it's time to contribute something.

This is just a small change that adds support for the --ignore-empty and --trim-by-grid options provided by the Aseprite CLI.

Hope you can make use of that (I'm sure I do :)