### PR TITLE
Loop configuration and exception prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Default loop value configuration.
 - Loop exception prefix configuration.
 
+### Fixed
+
+- wizard dock was not persisting pre-filled options if not closed.
+
 ### Thanks
 
-Thanks to Micky (@Mickeon) for suggesting this feature.
+Thanks to Micky (@Mickeon) for suggesting the loop prefix feature.
 
 ## 2.1.1 (2021-10-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 3.0.0 (2021-11-20)
+
+### Breaking changes
+
+- Animations starting with `_` will be set as non loopable (loop = false). Both default loop configuration and the exception prefix can be changed via configuration window.
+
+### Added
+
+- Default loop value configuration.
+- Loop exception prefix configuration.
+
+### Thanks
+
+Thanks to Micky (@Mickeon) for suggesting this feature.
+
 ## 2.1.1 (2021-10-20)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ It also adds Aseprite importer to Godot, so you can use `*.ase` and `*.aseprite`
 - Converts Aseprite frame duration (defined in milliseconds) to Godot's animation FPS. This way you can create your animation with the right timing in Aseprite, and it should work the same way in Godot.
 - Choose to export Aseprite file as single SpriteFrames resource, or separate each layer as its own resource.
 - Filter out layers you don't want in the final animation, using regex.
-- Supports Aseprite animation direction (forward, reverse, ping-pong)
+- Supports Aseprite animation direction (forward, reverse, ping-pong).
+- Supports loopable and non-loopable animations.
 - Adds Aseprite file importer to Godot (check limitations section).
 - (Importer only) Suppports importing Aseprite files as SpriteFrames, Atlas Texture, Animated Texture and Texture strip.
 
@@ -36,7 +37,7 @@ If you are using Windows, a portable version or if the `aseprite` command is not
 | Enable Aseprite Importer   | Enable/Disable Aseprite automatic importer. Default: `true` |
 | Remove Source Files   | Remove `*.json` and `*.png` files generated during import in Wizard. Default: `false` |
 | Loop animations       | Default animation loop configuration. Default: `true` |
-| Loop exception prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The Prefix is removed from animation name (i.e  `_death` > `death`). Default: `_` |
+| Loop exception prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The prefix is removed from the animation name (i.e  `_death` > `death`). Default: `_` |
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If you are using Windows, a portable version or if the `aseprite` command is not
 | Aseprite Command Path   | Path to the aseprite executable. Default: `aseprite` |
 | Enable Aseprite Importer   | Enable/Disable Aseprite automatic importer. Default: `true` |
 | Remove Source Files   | Remove `*.json` and `*.png` files generated during import in Wizard. Default: `false` |
+| Loop animations       | Default animation loop configuration. Default: `true` |
+| Loop exception prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The Prefix is removed from animation name (i.e  `_death` > `death`). Default: `_` |
 
 ## How to use
 
@@ -99,9 +101,11 @@ The plugin uses `aseprite` as default command. In case your system uses a differ
 
 ### Non-looping animations
 
-Aseprite does not have the concept of Loop / single run animations, as in Godot. Because of that, all animations are imported with Loop on. To disable it, you need to open the resource in the editor and uncheck the loop toggle (it won't work if you are using the importer flow).
+Aseprite does not have the concept of loop / single run animations, as in Godot. Because of that, looping is handled via a configured convention.
 
-Loops are useful for running, walking and idle cycles. Single run is useful for death, attack and engage animations.
+By default, all animations are imported with loop = true. Any animation starting with `_` (the exception prefix), will be imported with loop = false.
+
+Both the default configuration and the exception prefix can be changed in the configuration window.
 
 ### Import overwrite previous files
 

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -40,6 +40,14 @@ func _aseprite_command() -> String:
 	return command
 
 
+func _loop_config_prefix() -> String:
+	return config.get_value('aseprite', 'loop_config_prefix', '_')
+
+
+func _is_loop_config_enabled() -> String:
+	return config.get_value('aseprite', 'loop_enabled', true)
+
+
 func _aseprite_list_layers(file_name: String, only_visible = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layers", file_name]
@@ -320,7 +328,14 @@ func _get_frames_from_content(content):
 	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
 
 
-func _add_animation_frames(sprite_frames, animation_name, frames, texture, direction = 'forward'):
+func _add_animation_frames(sprite_frames, anim_name, frames, texture, direction = 'forward'):
+	var animation_name = anim_name
+	var is_loopable = _is_loop_config_enabled()
+
+	if animation_name.begins_with(_loop_config_prefix()):
+		animation_name = anim_name.substr(_loop_config_prefix().length())
+		is_loopable = not is_loopable
+
 	sprite_frames.add_animation(animation_name)
 
 	var min_duration = _get_min_duration(frames)
@@ -346,7 +361,7 @@ func _add_animation_frames(sprite_frames, animation_name, frames, texture, direc
 			for _i in range(number_of_sprites):
 				sprite_frames.add_frame(animation_name, atlas)
 
-	sprite_frames.set_animation_loop(animation_name, true)
+	sprite_frames.set_animation_loop(animation_name, is_loopable)
 	sprite_frames.set_animation_speed(animation_name, fps)
 
 func _calculate_fps(min_duration: int) -> float:

--- a/addons/AsepriteWizard/aseprite_cmd.gd
+++ b/addons/AsepriteWizard/aseprite_cmd.gd
@@ -352,7 +352,8 @@ func _add_animation_frames(sprite_frames, anim_name, frames, texture, direction 
 
 	if direction == 'pingpong':
 		frames.remove(frames.size() - 1)
-		frames.remove(0)
+		if is_loopable:
+			frames.remove(0)
 		frames.invert()
 
 		for frame in frames:

--- a/addons/AsepriteWizard/config_dialog.gd
+++ b/addons/AsepriteWizard/config_dialog.gd
@@ -7,6 +7,10 @@ const _CONFIG_SECTION_KEY = 'aseprite'
 const _COMMAND_KEY = 'command'
 const _IMPORTER_ENABLE_KEY = 'is_importer_enabled'
 const _REMOVE_SOURCE_FILES_KEY = 'remove_source_files'
+const _LOOP_ENABLED = 'loop_enabled'
+const _LOOP_EXCEPTION_PREFIX = 'loop_config_prefix'
+
+const _DEFAULT_LOOP_EX_PREFIX = '_'
 
 var config: ConfigFile
 
@@ -15,7 +19,8 @@ func _ready():
 	_aseprite_command_field().text = config.get_value(_CONFIG_SECTION_KEY, _COMMAND_KEY, get_default_command())
 	_importer_enable_field().pressed = config.get_value(_CONFIG_SECTION_KEY, _IMPORTER_ENABLE_KEY, true)
 	_remove_source_files_field().pressed = config.get_value(_CONFIG_SECTION_KEY, _REMOVE_SOURCE_FILES_KEY, false)
-
+	_enable_animation_loop().pressed = config.get_value(_CONFIG_SECTION_KEY, _LOOP_ENABLED, true)
+	_loop_ex_prefix().text = config.get_value(_CONFIG_SECTION_KEY, _LOOP_EXCEPTION_PREFIX, _DEFAULT_LOOP_EX_PREFIX)
 
 func init(config_file: ConfigFile):
 	config = config_file
@@ -32,6 +37,8 @@ func _on_save_button_up():
 		self.emit_signal("importer_state_changed")
 
 	config.set_value(_CONFIG_SECTION_KEY, _REMOVE_SOURCE_FILES_KEY, _remove_source_files_field().pressed)
+	config.set_value(_CONFIG_SECTION_KEY, _LOOP_EXCEPTION_PREFIX, _loop_ex_prefix().text if _loop_ex_prefix().text != "" else _DEFAULT_LOOP_EX_PREFIX)
+	config.set_value(_CONFIG_SECTION_KEY, _LOOP_ENABLED, _enable_animation_loop().pressed)
 
 	self.hide()
 
@@ -54,3 +61,11 @@ func _importer_enable_field() -> CheckBox:
 
 func _remove_source_files_field() -> CheckBox:
 	return $MarginContainer/VBoxContainer/remove_source as CheckBox
+
+
+func _enable_animation_loop() -> CheckBox:
+	return $MarginContainer/VBoxContainer/loop_animations as CheckBox
+
+
+func _loop_ex_prefix() -> LineEdit:
+	return $MarginContainer/VBoxContainer/loop/loop_config_prefix as LineEdit

--- a/addons/AsepriteWizard/config_dialog.gd
+++ b/addons/AsepriteWizard/config_dialog.gd
@@ -2,6 +2,7 @@ tool
 extends PopupPanel
 
 signal importer_state_changed
+signal config_saved
 
 const _CONFIG_SECTION_KEY = 'aseprite'
 const _COMMAND_KEY = 'command'
@@ -39,7 +40,7 @@ func _on_save_button_up():
 	config.set_value(_CONFIG_SECTION_KEY, _REMOVE_SOURCE_FILES_KEY, _remove_source_files_field().pressed)
 	config.set_value(_CONFIG_SECTION_KEY, _LOOP_EXCEPTION_PREFIX, _loop_ex_prefix().text if _loop_ex_prefix().text != "" else _DEFAULT_LOOP_EX_PREFIX)
 	config.set_value(_CONFIG_SECTION_KEY, _LOOP_ENABLED, _enable_animation_loop().pressed)
-
+	emit_signal("config_saved")
 	self.hide()
 
 

--- a/addons/AsepriteWizard/config_dialog.tscn
+++ b/addons/AsepriteWizard/config_dialog.tscn
@@ -2,8 +2,7 @@
 
 [ext_resource path="res://addons/AsepriteWizard/config_dialog.gd" type="Script" id=1]
 
-[node name="config_dialog" type="PopupPanel"]
-visible = true
+[node name="config_dialog2" type="PopupPanel"]
 margin_right = 400.0
 margin_bottom = 250.0
 rect_min_size = Vector2( 400, 250 )
@@ -29,7 +28,7 @@ __meta__ = {
 margin_left = 40.0
 margin_top = 40.0
 margin_right = 352.0
-margin_bottom = 216.0
+margin_bottom = 328.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 20
@@ -67,10 +66,47 @@ margin_bottom = 136.0
 hint_tooltip = "Wizard only: removes *.json and *.png files generated during import."
 text = "Remove source files"
 
-[node name="VBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+[node name="loop_animations" type="CheckBox" parent="MarginContainer/VBoxContainer"]
 margin_top = 156.0
 margin_right = 312.0
-margin_bottom = 176.0
+margin_bottom = 180.0
+hint_tooltip = "Default loop value for animations"
+pressed = true
+text = "Loop animations"
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="loop" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+margin_top = 200.0
+margin_right = 312.0
+margin_bottom = 248.0
+hint_tooltip = "Animations starting with this prefix should be imported with opposite loop configuration. Prefix is removed from animation name."
+custom_constants/separation = 10
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="loop_prefix_label" type="Label" parent="MarginContainer/VBoxContainer/loop"]
+margin_right = 312.0
+margin_bottom = 14.0
+mouse_filter = 1
+text = "Loop exception prefix"
+
+[node name="loop_config_prefix" type="LineEdit" parent="MarginContainer/VBoxContainer/loop"]
+margin_top = 24.0
+margin_right = 312.0
+margin_bottom = 48.0
+text = "_"
+caret_blink = true
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="VBoxContainer2" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+margin_top = 268.0
+margin_right = 312.0
+margin_bottom = 288.0
 custom_constants/separation = 30
 alignment = 2
 
@@ -85,5 +121,6 @@ margin_left = 271.0
 margin_right = 312.0
 margin_bottom = 20.0
 text = "Save"
+
 [connection signal="button_up" from="MarginContainer/VBoxContainer/VBoxContainer2/close" to="." method="_on_close_button_up"]
 [connection signal="button_up" from="MarginContainer/VBoxContainer/VBoxContainer2/save" to="." method="_on_save_button_up"]

--- a/addons/AsepriteWizard/first_options_window.gd
+++ b/addons/AsepriteWizard/first_options_window.gd
@@ -3,6 +3,7 @@ extends PanelContainer
 
 signal importer_state_changed
 signal close_requested
+signal save_requested
 
 const CONFIG_SECTION_KEY = 'file_locations'
 const LAST_SOURCE_PATH_KEY = 'source'
@@ -32,6 +33,7 @@ func _ready():
 	config_window = config_dialog.instance()
 	config_window.init(config)
 	config_window.connect("importer_state_changed", self, "_notify_importer_state_changed")
+	config_window.connect("config_saved", self, "emit_signal" , ["save_requested"])
 	aseprite.init(config, config_window.get_default_command(), file_system)
 
 	get_parent().add_child(file_dialog_aseprite)
@@ -152,7 +154,7 @@ func _save_config():
 	config.set_value(CONFIG_SECTION_KEY, ONLY_VISIBLE_LAYERS_KEY, _only_visible_layers_field().pressed)
 	config.set_value(CONFIG_SECTION_KEY, TRIM_MODE_KEY, _trim_image_field().selected)
 	config.set_value(CONFIG_SECTION_KEY, DO_NOT_CREATE_RES_KEY, _do_not_create_res_field().pressed)
-
+	emit_signal("save_requested")
 
 func _on_config_button_up():
 	config_window.popup_centered()

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Wizard and Importer for working with Aseprite files as SpriteFrames in Godot."
 author="Vinicius Gerevini"
-version="2.1.1"
+version="3.0.0"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -46,16 +46,21 @@ func _open_window(_ud):
 	window.init(config, get_editor_interface().get_resource_filesystem())
 	window.connect("importer_state_changed", self, "_on_importer_state_changed")
 	window.connect("close_requested", self, "_on_window_closed")
+	window.connect("save_requested", self, "_on_save_config")
 	add_control_to_bottom_panel(window, "Aseprite Wizard")
 	make_bottom_panel_item_visible(window)
 
 
+func _on_save_config():
+	config.save(CONFIG_FILE_PATH)
+
+
 func _on_window_closed():
 	if window:
-		config.save(CONFIG_FILE_PATH)
 		remove_control_from_bottom_panel(window)
 		window.queue_free()
 		window = null
+
 
 
 func _on_importer_state_changed():

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "AsepriteWizard" )
+enabled=PoolStringArray( "res://addons/AsepriteWizard/plugin.cfg" )
 
 [rendering]
 


### PR DESCRIPTION
closes #33 

- Added configuration to change default loop value.
- Added configuration to allow animations to be imported with opposite configuration.
- Prefix is removed from the animation name.

![Configuration screen](https://user-images.githubusercontent.com/4930052/142716656-cb3a10cf-7cd5-4413-9c20-6ae8081ccd13.png)

Here are some examples.

For configuration `Loop animations = true` and `Loop exception prefix = "_"`:

```
Animations in Aseprite:  walk  run  _attack  _engage

Result in Godot:
- walk (loop = true)
- run (loop = true)
- attack (loop = false)
- engage (loop = false)
```

For configuration `Loop animations = false` and `Loop exception prefix = "loop_"`:

```
Animations in Aseprite:  loop_walk  loop_run  attack engage

Result in Godot:
- walk (loop = true)
- run (loop = true)
- attack (loop = false)
- engage (loop = false)
```