### PR TITLE
Add config for inner padding

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/ASWizardWindow.tscn
+++ b/addons/AsepriteWizard/animated_sprite/ASWizardWindow.tscn
@@ -143,7 +143,7 @@ caret_blink = true
 [node name="layer_importing_mode" type="VBoxContainer" parent="container/options"]
 margin_top = 272.0
 margin_right = 526.0
-margin_bottom = 418.0
+margin_bottom = 452.0
 custom_constants/separation = 10
 
 [node name="label" type="Label" parent="container/options/layer_importing_mode"]
@@ -237,10 +237,30 @@ text = "Disabled"
 items = [ "Disabled", null, false, 0, null, "Trim", null, false, 1, null, "Trim by Grid", null, false, 2, null ]
 selected = 0
 
-[node name="buttons" type="HBoxContainer" parent="container/options"]
-margin_top = 438.0
+[node name="inner_padding" type="HBoxContainer" parent="container/options/layer_importing_mode"]
+margin_top = 156.0
 margin_right = 526.0
-margin_bottom = 458.0
+margin_bottom = 180.0
+hint_tooltip = "Adds padding inside each sprite in the output sheet. This can help prevent tearing."
+
+[node name="label" type="Label" parent="container/options/layer_importing_mode/inner_padding"]
+margin_top = 5.0
+margin_right = 250.0
+margin_bottom = 19.0
+rect_min_size = Vector2( 250, 0 )
+text = "Inner padding (px)"
+
+[node name="field" type="SpinBox" parent="container/options/layer_importing_mode/inner_padding"]
+margin_left = 254.0
+margin_right = 328.0
+margin_bottom = 24.0
+max_value = 20.0
+allow_greater = true
+
+[node name="buttons" type="HBoxContainer" parent="container/options"]
+margin_top = 472.0
+margin_right = 526.0
+margin_bottom = 492.0
 custom_constants/separation = 30
 alignment = 2
 

--- a/addons/AsepriteWizard/animated_sprite/sf_wizard_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/sf_wizard_dock.gd
@@ -105,6 +105,7 @@ func _on_next_btn_up():
 		"only_visible_layers": _only_visible_layers_field().pressed,
 		"trim_images": _trim_image_field().selected == 1,
 		"trim_by_grid": _trim_image_field().selected == 2,
+		"inner_padding": _inner_padding_field().get_value(),
 		"output_filename": _custom_name_field().text,
 		"do_not_create_resource": _do_not_create_res_field().pressed,
 		"remove_source_files_allowed": true
@@ -175,6 +176,10 @@ func _only_visible_layers_field() -> CheckBox:
 
 func _trim_image_field() -> OptionButton:
 	return $container/options/layer_importing_mode/trim_mode/field as OptionButton
+
+
+func _inner_padding_field() -> SpinBox:
+	return $container/options/layer_importing_mode/inner_padding/field as SpinBox
 
 
 func _custom_name_field() -> LineEdit:

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -136,7 +136,10 @@ func _export_command_common_arguments(source_name, data_path, spritesheet_path, 
 
 	if options.get('trim_by_grid', false):
 		arguments.push_front('--trim-by-grid')
-	
+
+	if options.get('inner_padding', 0) > 0:
+		arguments = ['--inner-padding', str(options.get('inner_padding'))] + arguments
+
 	return arguments
 
 


### PR DESCRIPTION
Hi there,

Thanks for building this wizard! I was experiencing some tearing in my sprites after having importing them with this plugin, and was able to fix it by using Aseprite's [inner padding](https://www.aseprite.org/docs/cli/#inner-padding) option. This makes sure there's a little space between the individual sprites so that the texture is allowed to sample from outside its defined area a bit. (Because apparently that happens!)

I added it to the wizard because it may help others.

Cheers!