### PR TITLE
Add inner padding config to AnimationPlayer options

### DIFF
--- a/addons/AsepriteWizard/animation_player/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/sprite_inspector_dock.gd
@@ -31,6 +31,7 @@ onready var _out_folder_field = $margin/VBoxContainer/options/out_folder/button
 onready var _out_filename_field = $margin/VBoxContainer/options/out_filename/LineEdit
 onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layers/CheckButton
 onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
+onready var _inner_padding_field = $margin/VBoxContainer/options/inner_padding/SpinBox
 
 func _ready():
 	var cfg = wizard_config.decode(sprite.editor_description)
@@ -171,7 +172,8 @@ func _on_import_pressed():
 		"exception_pattern": _ex_pattern_field.text,
 		"only_visible_layers": _visible_layers_field.pressed,
 		"output_filename": _out_filename_field.text,
-		"layer": _layer
+		"layer": _layer,
+		"inner_padding": _inner_padding_field.get_value()
 	}
 
 	_save_config()

--- a/addons/AsepriteWizard/animation_player/sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/sprite_inspector_dock.tscn
@@ -149,7 +149,7 @@ align = 0
 visible = false
 margin_top = 120.0
 margin_right = 198.0
-margin_bottom = 240.0
+margin_bottom = 268.0
 
 [node name="out_folder" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_right = 198.0
@@ -215,10 +215,31 @@ margin_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
-[node name="visible_layers" type="HBoxContainer" parent="margin/VBoxContainer/options"]
+[node name="inner_padding" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_top = 80.0
 margin_right = 198.0
-margin_bottom = 120.0
+margin_bottom = 104.0
+hint_tooltip = "Adds padding inside each sprite in the output sheet. This can help prevent tearing."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/options/inner_padding"]
+margin_top = 5.0
+margin_right = 115.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Inner padding (px)"
+
+[node name="SpinBox" type="SpinBox" parent="margin/VBoxContainer/options/inner_padding"]
+margin_left = 119.0
+margin_right = 198.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="visible_layers" type="HBoxContainer" parent="margin/VBoxContainer/options"]
+margin_top = 108.0
+margin_right = 198.0
+margin_bottom = 148.0
 hint_tooltip = "If active, layers not visible in the source file won't be included in the final image."
 
 [node name="Label" type="Label" parent="margin/VBoxContainer/options/visible_layers"]

--- a/addons/AsepriteWizard/animation_player/sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/sprite_inspector_dock.tscn
@@ -235,6 +235,9 @@ margin_right = 198.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
+max_value = 20.0
+rounded = true
+allow_greater = true
 
 [node name="visible_layers" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_top = 108.0

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -16,10 +16,14 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 	var data_file = "%s/%s.json" % [output_dir, basename]
 	var sprite_sheet = "%s/%s.png" % [output_dir, basename]
 	var output = []
+	var inner_padding = options.get('inner_padding', 0)
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 
 	if not only_visible_layers:
 		arguments.push_front("--all-layers")
+
+	if inner_padding > 0:
+		arguments = ['--inner-padding', str(inner_padding)] + arguments
 
 	_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
 


### PR DESCRIPTION
Opening this to replace #45. This adds the inner padding config ONLY to the `AnimationPlayer` import dock in the inspector. (It is not in the wizard in this PR.)