### PR TITLE
fix: do not round SpriteFrames FPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+
+## 4.0.1 (2022-02-08)
+
+### Fixed
+
+- SpriteFrames FPS was being rounded down, while they should've be rounded up.
+
 ## 4.0.0 (2022-01-23)
 
 The highlight in this version is the addition of `AnimationPlayer` support and a simplified flow for `AnimatedSprite`s. It also contains a major code refactor and improvements to the configuration options.

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -236,7 +236,7 @@ func _add_animation_frames(sprite_frames, anim_name, frames, texture, direction 
 
 
 func _calculate_fps(min_duration: int) -> float:
-	return ceil(1000 / min_duration)
+	return ceil(1000.0 / min_duration)
 
 
 func _get_min_duration(frames) -> int:

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Import Aseprite files to AnimationPlayers, AnimatedSprites and SpriteFrames."
 author="Vinicius Gerevini"
-version="4.0.0"
+version="4.0.1"
 script="plugin.gd"


### PR DESCRIPTION
As reported [here](https://www.youtube.com/watch?v=1W-CCbrzG_0&lc=UgwPI7TK9oCmdyoGFDN4AaABAg), even though the code was rounding it up, due to the int/float conversion, it was actually rounding down, causing slower animations.