### PR TITLE
Add "Sheet Type" importer option

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -36,23 +36,26 @@ func get_preset_name(i):
 
 func get_import_options(i):
 	return [
-		{"name": "split_layers", "default_value": false},
+		{"name": "split_layers",           "default_value": false},
 		{"name": "exclude_layers_pattern", "default_value": ''},
-		{"name": "only_visible_layers", "default_value": false},
+		{"name": "only_visible_layers",    "default_value": false},
+		
+		{"name": "sheet_type", "default_value": "Packed", "property_hint": PROPERTY_HINT_ENUM, 
+			"hint_string": get_sheet_type_hint_string()},
 
 		{"name": "sprite_filename_pattern", "default_value": "{basename}.{layer}.{extension}"},
 
 		{"name": "texture_strip/import_texture_strip", "default_value": false},
-		{"name": "texture_strip/filename_pattern", "default_value": "{basename}.{layer}.Strip.{extension}"},
+		{"name": "texture_strip/filename_pattern",     "default_value": "{basename}.{layer}.Strip.{extension}"},
 
-		{"name": "texture_atlas/import_texture_atlas", "default_value": false},
-		{"name": "texture_atlas/filename_pattern", "default_value": "{basename}.{layer}.Atlas.{extension}"},
+		{"name": "texture_atlas/import_texture_atlas",   "default_value": false},
+		{"name": "texture_atlas/filename_pattern",       "default_value": "{basename}.{layer}.Atlas.{extension}"},
 		{"name": "texture_atlas/frame_filename_pattern", "default_value": "{basename}.{layer}.{animation}.{frame}.Atlas.{extension}"},
 
 		{"name": "animated_texture/import_animated_texture", "default_value": false},
-		{"name": "animated_texture/filename_pattern", "default_value": "{basename}.{layer}.{animation}.Texture.{extension}"},
-		{"name": "animated_texture/frame_filename_pattern", "default_value": "{basename}.{layer}.{animation}.{frame}.Texture.{extension}"},
-		]
+		{"name": "animated_texture/filename_pattern",        "default_value": "{basename}.{layer}.{animation}.Texture.{extension}"},
+		{"name": "animated_texture/frame_filename_pattern",  "default_value": "{basename}.{layer}.{animation}.{frame}.Texture.{extension}"},
+	]
 
 
 func get_option_visibility(option, options):
@@ -66,6 +69,12 @@ static func replace_vars(pattern : String, vars : Dictionary):
 		result = result.replace("{%s}" % k, v)
 	return result
 
+static func get_sheet_type_hint_string() -> String:
+	var hint_string := "Packed"
+	for number in [2, 4, 8, 16, 32]:
+		hint_string += ",%s columns" % number
+	hint_string += ",Strip"
+	return hint_string
 
 func import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
@@ -97,11 +106,12 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		"export_mode": export_mode,
 		"exception_pattern": options['exclude_layers_pattern'],
 		"only_visible_layers": options['only_visible_layers'],
-		"output_filename": ''
+		"output_filename": '',
+		"column_count" : int(options['sheet_type']) if options['sheet_type'] != "Strip" else 128,
 	}
 
 	var exit_code = _sf_creator.create_resource(absolute_source_file, absolute_save_path, aseprite_opts)
-	if exit_code != 0:
+	if exit_code != OK:
 		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(exit_code))
 		return FAILED
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -6,7 +6,10 @@ var _config
 func init(config):
 	_config = config
 
-
+#{
+#	'data_file': file path to the json file
+#	"sprite_sheet": file path to the raw image file
+#}
 func export_file(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
@@ -20,6 +23,8 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 
 	if not only_visible_layers:
 		arguments.push_front("--all-layers")
+
+	_add_sheet_type_arguments(arguments, options)
 
 	_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
 
@@ -60,6 +65,8 @@ func export_layer(file_name: String, layer_name: String, output_folder: String, 
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 	arguments.push_front(layer_name)
 	arguments.push_front("--layer")
+	
+	_add_sheet_type_arguments(arguments, options)
 
 	var exit_code = _execute(arguments, output)
 	if exit_code != 0:
@@ -79,6 +86,15 @@ func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_
 		for l in layers:
 			arguments.push_front(l)
 			arguments.push_front('--ignore-layer')
+
+func _add_sheet_type_arguments(arguments: Array, options : Dictionary):
+	var column_count : int = options.get("column_count", 0)
+	if column_count > 0:
+		arguments.push_back("--merge-duplicates") # Yes, this is undocumented
+		arguments.push_back("--sheet-columns")
+		arguments.push_back(column_count)
+	else:
+		arguments.push_back("--sheet-pack")
 
 
 func _get_exception_layers(file_name: String, exception_pattern: String) -> Array:
@@ -119,7 +135,6 @@ func _export_command_common_arguments(source_name: String, data_path: String, sp
 	return [
 		"-b",
 		"--list-tags",
-		"--sheet-pack",
 		"--data",
 		data_path,
 		"--format",


### PR DESCRIPTION
This PR adds a "Sheet Type" option to the Aseprite Importer.
It can be one of the following:
* "Packed" (_same behaviour as of now, default_)
* "2 columns"
* "4 columns"
* "8 columns"
* "16 columns"
* "32 columns"
* "Strip" (_similar behaviour before v4.0.0, 128 columns is normally hard to reach_)

All of the non-default settings are optimised to not generate duplicate across the Atlas, thanks to `--merge-duplicate`, _yes this is an argument_.

This does not typically come useful for the default **SpriteFrames** import, but it can be handy in when exporting a Texture Strip, as the default Packed option causes the strip to inconsistently resize when adding or removing frames.
Please feel free to cherry-pick or outright discard.