### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+**/**       export-ignore
+
+addons      !export-ignore
+addons/**   !export-ignore


### PR DESCRIPTION
This will fix the unnecessary files when a user downloads the addon from the Godot Asset Lib:

![image](https://user-images.githubusercontent.com/20030153/169434222-47b4acf5-ad2b-489b-8e7b-0a9841e66b38.png)

Read here for more information: https://github.com/godotengine/godot-proposals/issues/3648

Link to test the download: https://github.com/gumaciel/godot-aseprite-wizard/archive/refs/heads/gitattributes-export-ignore-unwanted-files.zip