### PR TITLE
Aseprite Wizard Dock History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mono_crash.*.json
 # System/tool-specific ignores
 .directory
 *~
+.aseprite_wizard_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+
+### Added
+
+- Wizard history tab to track imports made via wizard screen. Options to order by date or path.
+
 ## 4.1.1 (2022-06-05)
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ If you are using Windows, a portable version or if the `aseprite` command is not
 | Loop exception prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The prefix is removed from the animation name on import (i.e  `_death` > `death`). Default: `_` |
 | Default layer exclusion pattern | Exclude layers with names matching this pattern (regex). This is the default value for new nodes. It can be changed or removed during the import. Default: not set |
 
+For more configurations check `Project -> Project Settings -> General > Aseprite`.
+
+| Configuration           | Description |
+| ----------------------- | ----------- |
+| Wizard > History > Cache File Path | Path to file where history data is stored. Default: `res://.aseprite_wizard_history` |
+| Wizard > History > Keep One Entry Per Source File | When true, history does not show duplicates. Default: `false` |
+
 ## How to use
 
 _Check this video for usage examples:_ https://youtu.be/1W-CCbrzG_0

--- a/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.gd
+++ b/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.gd
@@ -1,0 +1,36 @@
+tool
+extends TabContainer
+
+signal close_requested
+
+const WizardWindow = preload("./ASWizardWindow.tscn")
+
+var _config
+var _file_system: EditorFileSystem
+
+func _ready():
+	$Import.init(_config, _file_system)
+	$Import.connect("close_requested", self, "emit_signal", ["close_requested"])
+	$Import.connect("import_success", $History, "add_entry")
+	$History.init(_config)
+	$History.connect("request_edit", self, "_on_edit_request")
+	$History.connect("request_import", self, "_on_import_request")
+
+
+func init(config, editor_file_system: EditorFileSystem):
+	_config = config
+	_file_system = editor_file_system
+
+
+func _on_AsWizardDockContainer_tab_changed(tab: int):
+	if tab == 1:
+		$History.reload()
+
+
+func _on_edit_request(import_cfg: Dictionary):
+	$Import.load_import_config(import_cfg)
+	self.current_tab = 0
+
+func _on_import_request(import_cfg: Dictionary):
+	$Import.load_import_config(import_cfg)
+	$Import.trigger_import()

--- a/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.gd
+++ b/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.gd
@@ -31,6 +31,7 @@ func _on_edit_request(import_cfg: Dictionary):
 	$Import.load_import_config(import_cfg)
 	self.current_tab = 0
 
+
 func _on_import_request(import_cfg: Dictionary):
 	$Import.load_import_config(import_cfg)
 	$Import.trigger_import()

--- a/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.tscn
+++ b/addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/ASWizardWindow.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/ASWizardDockContainer.gd" type="Script" id=2]
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.tscn" type="PackedScene" id=3]
+
+[node name="AsWizardDockContainer" type="TabContainer"]
+margin_right = 281.0
+margin_bottom = 36.0
+tab_align = 2
+use_hidden_tabs_for_min_size = true
+script = ExtResource( 2 )
+
+[node name="Import" parent="." instance=ExtResource( 1 )]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+hint_tooltip = "SpriteFrames Importer"
+
+[node name="History" parent="." instance=ExtResource( 3 )]
+visible = false
+
+[connection signal="tab_changed" from="." to="." method="_on_AsWizardDockContainer_tab_changed"]

--- a/addons/AsepriteWizard/animated_sprite/ASWizardWindow.tscn
+++ b/addons/AsepriteWizard/animated_sprite/ASWizardWindow.tscn
@@ -9,9 +9,6 @@ rect_min_size = Vector2( 600, 600 )
 size_flags_horizontal = 3
 size_flags_vertical = 0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="container" type="MarginContainer" parent="."]
 margin_left = 7.0

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
@@ -1,0 +1,151 @@
+tool
+extends PanelContainer
+
+signal request_edit(import_cfg)
+signal request_import(import_cfg)
+
+const SourcePathField = preload("./wizard_nodes/source_path.tscn")
+const OutputPathField = preload("./wizard_nodes/output_path.tscn")
+const ImportDateField = preload("./wizard_nodes/import_date.tscn")
+const ItemActions = preload("./wizard_nodes/list_actions.tscn")
+
+# TODO option: one entry per file (when importing, if file already exists, remove from list)
+# TODO option: limit history size. (when importing, if history is at limit, remove last item from list)
+
+var _config
+var _history: Dictionary
+
+var _history_nodes := {}
+var _is_busy := false
+
+onready var grid = $MarginContainer/VBoxContainer/ScrollContainer/GridContainer
+onready var loading_warning = $MarginContainer/VBoxContainer/loading_warning
+onready var no_history_warning = $MarginContainer/VBoxContainer/no_history_warning
+
+func init(config):
+	_config = config
+
+
+func reload():
+	if _history:
+		return
+	_history = _config.get_import_history()
+
+	for index in range(_history.entries.size()):
+		var entry = _history.entries[index]
+		_add_to_node_list(entry, _create_nodes(entry, index))
+
+	loading_warning.hide()
+
+	if _history.entries.empty():
+		no_history_warning.show()
+	else:
+		grid.get_parent().show()
+
+
+func _create_nodes(entry: Dictionary, index: int) -> Dictionary:
+	var source_path = SourcePathField.instance()
+	source_path.set_entry(entry)
+	grid.add_child_below_node(grid.get_child(3), source_path)
+
+	var output_path = OutputPathField.instance()
+	output_path.text = entry.output_location
+	grid.add_child_below_node(source_path, output_path)
+
+	var import_date = ImportDateField.instance()
+	import_date.set_date(entry.import_date)
+	grid.add_child_below_node(output_path, import_date)
+
+	var actions = ItemActions.instance()
+	actions.history_index = index
+	grid.add_child_below_node(import_date, actions)
+
+	actions.connect("import_clicked", self, "_on_entry_reimport_clicked")
+	actions.connect("edit_clicked", self, "_on_entry_edit_clicked")
+	actions.connect("removed_clicked", self, "_on_entry_remove_clicked")
+
+	return {
+		"history_index": index,
+		"source_path_node": source_path,
+		"output_path_node": output_path,
+		"import_date_node": import_date,
+		"actions_node": actions,
+	}
+
+func add_entry(file_settings: Dictionary):
+	print(" ADD NEW ENTRY ")
+	print(file_settings)
+	if not _history:
+		reload()
+	file_settings["import_date"] = OS.get_unix_time()
+
+	# TODO if unique, remove existing ones, otherwise just add to the list.
+
+	_history.entries.push_back(file_settings)
+	_config.save_import_history(_history)
+	_add_to_node_list(file_settings, _create_nodes(file_settings, _history.entries.size() - 1))
+
+	no_history_warning.hide()
+	grid.get_parent().show()
+	_is_busy = false
+
+
+func _on_entry_reimport_clicked(entry_index: int):
+	if _is_busy:
+		return
+	_is_busy = true
+	emit_signal("request_import", _history.entries[entry_index])
+
+
+func _on_entry_edit_clicked(entry_index: int):
+	if _is_busy:
+		return
+	emit_signal("request_edit", _history.entries[entry_index])
+
+
+func _on_entry_remove_clicked(entry_index: int):
+	if _is_busy:
+		return
+	_is_busy = true
+
+	_remove_item(entry_index)
+	_config.save_import_history(_history)
+
+	if (_history.entries.empty()):
+		grid.get_parent().hide()
+		no_history_warning.show()
+
+	_is_busy = false
+
+
+func _remove_item(entry_index: int):
+	var entry = _history.entries[entry_index]
+	var files_entries = _history_nodes[entry.source_file]
+
+	# removes from node list
+	for f in files_entries:
+		if f.history_index == entry_index:
+			f.source_path_node.queue_free()
+			f.output_path_node.queue_free()
+			f.import_date_node.queue_free()
+			f.actions_node.queue_free()
+			files_entries.erase(f)
+			break
+
+	_history.entries.remove(entry_index)
+
+	# to avoid re-creating the whole nodes list, I just decrement
+	# the index from items newer than excluded one
+	for index in range(entry_index, _history.entries.size()):
+		var nodes = _history_nodes[_history.entries[index].source_file]
+		for f in nodes:
+			if f.history_index > entry_index:
+				f.history_index -= 1
+				f.actions_node.history_index = f.history_index
+				print("update index")
+
+
+func _add_to_node_list(entry: Dictionary, node: Dictionary):
+	if not _history_nodes.has(entry.source_file):
+		_history_nodes[entry.source_file] = []
+	_history_nodes[entry.source_file].push_back(node)

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
@@ -10,7 +10,6 @@ const ImportDateField = preload("./wizard_nodes/import_date.tscn")
 const ItemActions = preload("./wizard_nodes/list_actions.tscn")
 
 # TODO option: one entry per file (when importing, if file already exists, remove from list)
-# TODO option: limit history size. (when importing, if history is at limit, remove last item from list)
 
 var _config
 var _history: Dictionary
@@ -135,7 +134,7 @@ func _remove_item(entry_index: int):
 	_history.entries.remove(entry_index)
 
 	# to avoid re-creating the whole nodes list, I just decrement
-	# the index from items newer than excluded one
+	# the index from items newer than the excluded one
 	for index in range(entry_index, _history.entries.size()):
 		var nodes = _history_nodes[_history.entries[index].source_file]
 		for f in nodes:

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
@@ -95,7 +95,8 @@ func add_entry(file_settings: Dictionary):
 	if not _history:
 		reload()
 
-	file_settings["import_date"] = OS.get_unix_time()
+	var dt = OS.get_datetime()
+	file_settings["import_date"] = "%04d-%02d-%02d %02d:%02d:%02d" % [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second]
 
 	if _import_requested_for != -1:
 		_remove_item(_import_requested_for)

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
@@ -9,13 +9,12 @@ const OutputPathField = preload("./wizard_nodes/output_path.tscn")
 const ImportDateField = preload("./wizard_nodes/import_date.tscn")
 const ItemActions = preload("./wizard_nodes/list_actions.tscn")
 
-# TODO option: one entry per file (when importing, if file already exists, remove from list)
-
 var _config
 var _history: Array
 
 var _history_nodes := {}
 var _is_busy := false
+var _import_requested_for := -1
 
 onready var grid = $MarginContainer/VBoxContainer/ScrollContainer/GridContainer
 onready var loading_warning = $MarginContainer/VBoxContainer/loading_warning
@@ -72,13 +71,15 @@ func _create_nodes(entry: Dictionary, index: int) -> Dictionary:
 	}
 
 func add_entry(file_settings: Dictionary):
-	print(" ADD NEW ENTRY ")
-	print(file_settings)
 	if not _history:
 		reload()
 	file_settings["import_date"] = OS.get_unix_time()
 
-	# TODO if unique, remove existing ones, otherwise just add to the list.
+	if _import_requested_for != -1:
+		_remove_item(_import_requested_for)
+		_import_requested_for = -1
+	elif _config.is_single_file_history() and _history_nodes.has(file_settings.source_file):
+		_remove_entries(file_settings.source_file)
 
 	_history.push_back(file_settings)
 	_config.save_import_history(_history)
@@ -93,6 +94,7 @@ func _on_entry_reimport_clicked(entry_index: int):
 	if _is_busy:
 		return
 	_is_busy = true
+	_import_requested_for = entry_index
 	emit_signal("request_import", _history[entry_index])
 
 
@@ -119,32 +121,57 @@ func _on_entry_remove_clicked(entry_index: int):
 
 func _remove_item(entry_index: int):
 	var entry = _history[entry_index]
-	var files_entries = _history_nodes[entry.source_file]
+	_remove_entries(entry.source_file, entry_index)
 
-	# removes from node list
+
+# removes nodes and entry from history. If entry_index is not provided, all
+# entries for path are removed.
+func _remove_entries(source_file_path: String, entry_index: int = -1):
+	var files_entries = _history_nodes[source_file_path]
+	var _index_to_remove = []
+
 	for f in files_entries:
-		if f.history_index == entry_index:
-			f.source_path_node.queue_free()
-			f.output_path_node.queue_free()
-			f.import_date_node.queue_free()
-			f.actions_node.queue_free()
-			files_entries.erase(f)
-			break
+		if entry_index == -1 or f.history_index == entry_index:
+			_free_entry_nodes(f)
 
-	_history.remove(entry_index)
+			if entry_index != -1:
+				files_entries.erase(f)
+				_remove_from_history(f.history_index)
+				return
 
+			_index_to_remove.push_back(f.history_index)
+
+	for i in _index_to_remove:
+		_remove_from_history(i)
+
+	_history_nodes[source_file_path] = []
+
+
+func _remove_from_history(entry_index: int):
+	var _already_adjusted = []
 	# to avoid re-creating the whole nodes list, I just decrement
 	# the index from items newer than the excluded one
-	for index in range(entry_index, _history.size()):
+	for index in range(entry_index + 1, _history.size()):
+		if _already_adjusted.has(_history[index].source_file):
+			continue
+		_already_adjusted.push_back(_history[index].source_file)
 		var nodes = _history_nodes[_history[index].source_file]
 		for f in nodes:
 			if f.history_index > entry_index:
 				f.history_index -= 1
 				f.actions_node.history_index = f.history_index
-				print("update index")
+
+	_history.remove(entry_index)
+
+
+func _free_entry_nodes(entry_history_node: Dictionary):
+	entry_history_node.source_path_node.queue_free()
+	entry_history_node.output_path_node.queue_free()
+	entry_history_node.import_date_node.queue_free()
+	entry_history_node.actions_node.queue_free()
 
 
 func _add_to_node_list(entry: Dictionary, node: Dictionary):
 	if not _history_nodes.has(entry.source_file):
 		_history_nodes[entry.source_file] = []
-	_history_nodes[entry.source_file].push_back(node)
+	_history_nodes[entry.source_file].push_front(node)

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd
@@ -12,7 +12,7 @@ const ItemActions = preload("./wizard_nodes/list_actions.tscn")
 # TODO option: one entry per file (when importing, if file already exists, remove from list)
 
 var _config
-var _history: Dictionary
+var _history: Array
 
 var _history_nodes := {}
 var _is_busy := false
@@ -30,13 +30,13 @@ func reload():
 		return
 	_history = _config.get_import_history()
 
-	for index in range(_history.entries.size()):
-		var entry = _history.entries[index]
+	for index in range(_history.size()):
+		var entry = _history[index]
 		_add_to_node_list(entry, _create_nodes(entry, index))
 
 	loading_warning.hide()
 
-	if _history.entries.empty():
+	if _history.empty():
 		no_history_warning.show()
 	else:
 		grid.get_parent().show()
@@ -80,9 +80,9 @@ func add_entry(file_settings: Dictionary):
 
 	# TODO if unique, remove existing ones, otherwise just add to the list.
 
-	_history.entries.push_back(file_settings)
+	_history.push_back(file_settings)
 	_config.save_import_history(_history)
-	_add_to_node_list(file_settings, _create_nodes(file_settings, _history.entries.size() - 1))
+	_add_to_node_list(file_settings, _create_nodes(file_settings, _history.size() - 1))
 
 	no_history_warning.hide()
 	grid.get_parent().show()
@@ -93,13 +93,13 @@ func _on_entry_reimport_clicked(entry_index: int):
 	if _is_busy:
 		return
 	_is_busy = true
-	emit_signal("request_import", _history.entries[entry_index])
+	emit_signal("request_import", _history[entry_index])
 
 
 func _on_entry_edit_clicked(entry_index: int):
 	if _is_busy:
 		return
-	emit_signal("request_edit", _history.entries[entry_index])
+	emit_signal("request_edit", _history[entry_index])
 
 
 func _on_entry_remove_clicked(entry_index: int):
@@ -110,7 +110,7 @@ func _on_entry_remove_clicked(entry_index: int):
 	_remove_item(entry_index)
 	_config.save_import_history(_history)
 
-	if (_history.entries.empty()):
+	if (_history.empty()):
 		grid.get_parent().hide()
 		no_history_warning.show()
 
@@ -118,7 +118,7 @@ func _on_entry_remove_clicked(entry_index: int):
 
 
 func _remove_item(entry_index: int):
-	var entry = _history.entries[entry_index]
+	var entry = _history[entry_index]
 	var files_entries = _history_nodes[entry.source_file]
 
 	# removes from node list
@@ -131,12 +131,12 @@ func _remove_item(entry_index: int):
 			files_entries.erase(f)
 			break
 
-	_history.entries.remove(entry_index)
+	_history.remove(entry_index)
 
 	# to avoid re-creating the whole nodes list, I just decrement
 	# the index from items newer than the excluded one
-	for index in range(entry_index, _history.entries.size()):
-		var nodes = _history_nodes[_history.entries[index].source_file]
+	for index in range(entry_index, _history.size()):
+		var nodes = _history_nodes[_history[index].source_file]
 		for f in nodes:
 			if f.history_index > entry_index:
 				f.history_index -= 1

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.tscn
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.tscn
@@ -1,0 +1,130 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.gd" type="Script" id=1]
+
+[node name="SpriteFramesImportHistory" type="PanelContainer"]
+anchor_right = 1.0
+rect_min_size = Vector2( 0, 600 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource( 1 )
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 1017.0
+margin_bottom = 593.0
+custom_constants/margin_right = 30
+custom_constants/margin_top = 30
+custom_constants/margin_left = 30
+custom_constants/margin_bottom = 30
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+margin_left = 30.0
+margin_top = 30.0
+margin_right = 980.0
+margin_bottom = 556.0
+
+[node name="list actions" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+visible = false
+margin_right = 950.0
+margin_bottom = 20.0
+size_flags_vertical = 0
+custom_constants/separation = 10
+alignment = 2
+
+[node name="mode_label" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
+margin_left = 704.0
+margin_top = 3.0
+margin_right = 744.0
+margin_bottom = 17.0
+text = "Mode:"
+
+[node name="mode_options" type="OptionButton" parent="MarginContainer/VBoxContainer/list actions"]
+margin_left = 754.0
+margin_right = 813.0
+margin_bottom = 20.0
+text = "View"
+items = [ "View", null, false, 0, null, "Edit", null, false, 1, null ]
+selected = 0
+
+[node name="divider" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
+margin_left = 823.0
+margin_top = 3.0
+margin_right = 823.0
+margin_bottom = 17.0
+
+[node name="sort_label" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
+margin_left = 833.0
+margin_top = 3.0
+margin_right = 881.0
+margin_bottom = 17.0
+text = "Sort by:"
+
+[node name="SortOptions" type="OptionButton" parent="MarginContainer/VBoxContainer/list actions"]
+margin_left = 891.0
+margin_right = 950.0
+margin_bottom = 20.0
+text = "Date"
+items = [ "Date", null, false, 0, null, "Path", null, false, 1, null ]
+selected = 0
+
+[node name="loading_warning" type="Label" parent="MarginContainer/VBoxContainer"]
+margin_top = 256.0
+margin_right = 950.0
+margin_bottom = 270.0
+size_flags_horizontal = 3
+size_flags_vertical = 6
+text = "Loading..."
+align = 1
+
+[node name="no_history_warning" type="Label" parent="MarginContainer/VBoxContainer"]
+visible = false
+margin_top = 388.0
+margin_right = 950.0
+margin_bottom = 402.0
+size_flags_horizontal = 3
+size_flags_vertical = 6
+text = "No import history"
+align = 1
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/VBoxContainer"]
+visible = false
+margin_top = 265.0
+margin_right = 950.0
+margin_bottom = 526.0
+size_flags_vertical = 3
+scroll_horizontal_enabled = false
+
+[node name="GridContainer" type="GridContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
+margin_right = 950.0
+margin_bottom = 58.0
+size_flags_horizontal = 3
+custom_constants/vseparation = 20
+custom_constants/hseparation = 10
+columns = 4
+
+[node name="source_label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/GridContainer"]
+margin_right = 440.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Source File"
+
+[node name="output_label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/GridContainer"]
+margin_left = 450.0
+margin_right = 650.0
+margin_bottom = 14.0
+text = "Output Folder"
+
+[node name="date_label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/GridContainer"]
+margin_left = 660.0
+margin_right = 774.0
+margin_bottom = 14.0
+text = "Date"
+
+[node name="actions_label" type="Label" parent="MarginContainer/VBoxContainer/ScrollContainer/GridContainer"]
+margin_left = 784.0
+margin_right = 950.0
+margin_bottom = 14.0
+text = "Actions"

--- a/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.tscn
+++ b/addons/AsepriteWizard/animated_sprite/SpriteFramesImportHistory.tscn
@@ -26,53 +26,38 @@ margin_right = 980.0
 margin_bottom = 556.0
 
 [node name="list actions" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
-visible = false
 margin_right = 950.0
 margin_bottom = 20.0
 size_flags_vertical = 0
 custom_constants/separation = 10
 alignment = 2
 
-[node name="mode_label" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
-margin_left = 704.0
-margin_top = 3.0
-margin_right = 744.0
-margin_bottom = 17.0
-text = "Mode:"
-
-[node name="mode_options" type="OptionButton" parent="MarginContainer/VBoxContainer/list actions"]
-margin_left = 754.0
-margin_right = 813.0
-margin_bottom = 20.0
-text = "View"
-items = [ "View", null, false, 0, null, "Edit", null, false, 1, null ]
-selected = 0
-
 [node name="divider" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
-margin_left = 823.0
+margin_left = 782.0
 margin_top = 3.0
-margin_right = 823.0
+margin_right = 782.0
 margin_bottom = 17.0
 
 [node name="sort_label" type="Label" parent="MarginContainer/VBoxContainer/list actions"]
-margin_left = 833.0
+margin_left = 792.0
 margin_top = 3.0
-margin_right = 881.0
+margin_right = 840.0
 margin_bottom = 17.0
 text = "Sort by:"
 
 [node name="SortOptions" type="OptionButton" parent="MarginContainer/VBoxContainer/list actions"]
-margin_left = 891.0
+margin_left = 850.0
 margin_right = 950.0
 margin_bottom = 20.0
+rect_min_size = Vector2( 100, 0 )
 text = "Date"
 items = [ "Date", null, false, 0, null, "Path", null, false, 1, null ]
 selected = 0
 
 [node name="loading_warning" type="Label" parent="MarginContainer/VBoxContainer"]
-margin_top = 256.0
+margin_top = 268.0
 margin_right = 950.0
-margin_bottom = 270.0
+margin_bottom = 282.0
 size_flags_horizontal = 3
 size_flags_vertical = 6
 text = "Loading..."
@@ -98,7 +83,7 @@ scroll_horizontal_enabled = false
 
 [node name="GridContainer" type="GridContainer" parent="MarginContainer/VBoxContainer/ScrollContainer"]
 margin_right = 950.0
-margin_bottom = 58.0
+margin_bottom = 14.0
 size_flags_horizontal = 3
 custom_constants/vseparation = 20
 custom_constants/hseparation = 10
@@ -128,3 +113,5 @@ margin_left = 784.0
 margin_right = 950.0
 margin_bottom = 14.0
 text = "Actions"
+
+[connection signal="item_selected" from="MarginContainer/VBoxContainer/list actions/SortOptions" to="." method="_on_SortOptions_item_selected"]

--- a/addons/AsepriteWizard/animated_sprite/sf_wizard_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/sf_wizard_dock.gd
@@ -90,8 +90,9 @@ func _create_outuput_folder_selection():
 
 
 func _on_aseprite_file_selected(path):
-	_file_location_field().text = path
-	_config.set_last_source_path(path)
+	var localized_path = ProjectSettings.localize_path(path)
+	_file_location_field().text = localized_path
+	_config.set_last_source_path(localized_path)
 
 
 func _on_output_folder_selected(path):
@@ -113,7 +114,10 @@ func _on_next_btn_up():
 		"do_not_create_resource": _do_not_create_res_field().pressed,
 		"remove_source_files_allowed": true
 	}
-	var exit_code = _sf_creator.create_resource(aseprite_file, output_location, options)
+	var exit_code = _sf_creator.create_resource(
+		ProjectSettings.globalize_path(aseprite_file),
+		output_location, options
+	)
 	if exit_code is GDScriptFunctionState:
 		exit_code = yield(exit_code, "completed")
 

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.gd
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.gd
@@ -1,0 +1,11 @@
+tool
+extends Label
+
+
+func set_date(timestamp: int):
+	self.text = _format_date(timestamp)
+
+
+func _format_date(timestamp: int) -> String:
+	var dt = OS.get_datetime_from_unix_time(timestamp)
+	return "%04d-%02d-%02d %02d:%02d:%02d" % [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second]

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.gd
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.gd
@@ -2,10 +2,11 @@ tool
 extends Label
 
 
-func set_date(timestamp: int):
-	self.text = _format_date(timestamp)
+func set_date(timestamp: String):
+	self.text = timestamp
+#	self.text = _format_date(timestamp)
 
 
-func _format_date(timestamp: int) -> String:
-	var dt = OS.get_datetime_from_unix_time(timestamp)
-	return "%04d-%02d-%02d %02d:%02d:%02d" % [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second]
+#func _format_date(timestamp: int) -> String:
+#	var dt = OS.get_datetime_from_unix_time(timestamp)
+#	return "%04d-%02d-%02d %02d:%02d:%02d" % [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second]

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.tscn
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/wizard_nodes/import_date.gd" type="Script" id=1]
+
+[node name="import_date" type="Label"]
+margin_left = 660.0
+margin_top = 39.0
+margin_right = 774.0
+margin_bottom = 53.0
+text = "2022-07-18 18:01"
+script = ExtResource( 1 )

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/list_actions.gd
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/list_actions.gd
@@ -1,0 +1,20 @@
+tool
+extends HBoxContainer
+
+signal import_clicked(index)
+signal edit_clicked(index)
+signal removed_clicked(index)
+
+var history_index = -1
+
+
+func _on_edit_pressed():
+	emit_signal("edit_clicked", history_index)
+
+
+func _on_reimport_pressed():
+	emit_signal("import_clicked", history_index)
+
+
+func _on_remove_pressed():
+	emit_signal("removed_clicked", history_index)

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/list_actions.tscn
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/list_actions.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/wizard_nodes/list_actions.gd" type="Script" id=1]
+
+[node name="actions" type="HBoxContainer"]
+margin_left = 784.0
+margin_top = 34.0
+margin_right = 950.0
+margin_bottom = 58.0
+custom_constants/separation = 5
+script = ExtResource( 1 )
+
+[node name="edit" type="Button" parent="."]
+margin_right = 36.0
+margin_bottom = 20.0
+size_flags_vertical = 0
+text = "Edit"
+
+[node name="reimport" type="Button" parent="."]
+margin_left = 41.0
+margin_right = 97.0
+margin_bottom = 20.0
+size_flags_vertical = 0
+text = "Import"
+
+[node name="remove" type="Button" parent="."]
+margin_left = 102.0
+margin_right = 166.0
+margin_bottom = 20.0
+size_flags_vertical = 0
+text = "Remove"
+
+[connection signal="pressed" from="edit" to="." method="_on_edit_pressed"]
+[connection signal="pressed" from="reimport" to="." method="_on_reimport_pressed"]
+[connection signal="pressed" from="remove" to="." method="_on_remove_pressed"]

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/output_path.tscn
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/output_path.tscn
@@ -1,0 +1,12 @@
+[gd_scene format=2]
+
+[node name="output_path" type="LineEdit"]
+margin_left = 450.0
+margin_top = 34.0
+margin_right = 650.0
+margin_bottom = 58.0
+rect_min_size = Vector2( 200, 0 )
+size_flags_vertical = 0
+text = "/some/output"
+align = 3
+editable = false

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/source_path.gd
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/source_path.gd
@@ -1,0 +1,22 @@
+tool
+extends LineEdit
+
+
+func set_entry(entry: Dictionary):
+	self.text = entry.source_file
+	self.hint_tooltip = _format_hint(entry)
+
+
+func _format_hint(entry: Dictionary) -> String:
+	return """Output filename/prefix: %s
+Ex. pattern: %s
+Split: %s
+Only visible: %s
+No Resource: %s
+""" % [
+	entry.options.output_filename,
+	entry.options.exception_pattern,
+	"yes" if entry.options.export_mode else "no",
+	"yes" if entry.options.only_visible_layers else "no",
+	"yes" if entry.options.do_not_create_resource else "no",
+]

--- a/addons/AsepriteWizard/animated_sprite/wizard_nodes/source_path.tscn
+++ b/addons/AsepriteWizard/animated_sprite/wizard_nodes/source_path.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/AsepriteWizard/animated_sprite/wizard_nodes/source_path.gd" type="Script" id=1]
+
+[node name="source_path" type="LineEdit"]
+margin_top = 34.0
+margin_right = 440.0
+margin_bottom = 58.0
+rect_min_size = Vector2( 200, 0 )
+hint_tooltip = "Output name / prefix: some_name
+Ex. Pattern: $_
+Split: Yes
+Only Visible: No
+No Resource: No"
+size_flags_vertical = 0
+text = "/some/very/long/source/path/to/test/field"
+editable = false
+script = ExtResource( 1 )

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -28,6 +28,9 @@ const _I_DO_NOT_CREATE_RES_KEY = 'disable_resource_creation'
 const PIXEL_2D_PRESET_CFG = 'res://addons/AsepriteWizard/config/2d_pixel_preset.cfg'
 const ASEPRITE_PROJECT_SETTINGS_IMPORT_PRESET = 'aseprite/import/preset'
 
+# HISTORY CONFIGS
+const HISTORY_CONFIG_FILE_PATH = 'user://aseprite_wizard_history.cfg'
+
 # INTERFACE CONFIGS
 var _icon_arrow_down: Texture
 var _icon_arrow_right: Texture
@@ -208,3 +211,21 @@ func set_icon_arrow_right(icon: Texture) -> void:
 
 func get_icon_arrow_right() -> Texture:
 	return _icon_arrow_right
+
+
+func get_import_history() -> Dictionary:
+	# TODO bring HISTORY_CONFIG_FILE_PATH from settings
+	var file_object = File.new()
+	if not file_object.file_exists(HISTORY_CONFIG_FILE_PATH):
+		return { "entries": [] }
+	file_object.open(HISTORY_CONFIG_FILE_PATH, File.READ)
+	var content =  parse_json(file_object.get_as_text())
+	file_object.close()
+	return content
+
+
+func save_import_history(history: Dictionary):
+	var file = File.new()
+	file.open(HISTORY_CONFIG_FILE_PATH, File.WRITE)
+	file.store_line(to_json(history))
+	file.close()

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -218,21 +218,30 @@ func get_icon_arrow_right() -> Texture:
 ######################################################
 
 
-func get_import_history() -> Dictionary:
+func get_import_history() -> Array:
+	var history = []
 	var history_path := _get_history_file_path()
 	var file_object = File.new()
+
 	if not file_object.file_exists(history_path):
-		return { "entries": [] }
+		return history
+
 	file_object.open(history_path, File.READ)
-	var content =  parse_json(file_object.get_as_text())
-	file_object.close()
-	return content
 
+	while not file_object.eof_reached():
+		var line = file_object.get_line()
+		if line:
+			history.push_back(parse_json(line))
 
-func save_import_history(history: Dictionary):
+	return history
+
+# history is saved and retrieved line-by-line so
+# file becomes version control friendly
+func save_import_history(history: Array):
 	var file = File.new()
 	file.open(_get_history_file_path(), File.WRITE)
-	file.store_line(to_json(history))
+	for entry in history:
+		file.store_line(to_json(entry))
 	file.close()
 
 

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -30,7 +30,8 @@ const ASEPRITE_PROJECT_SETTINGS_IMPORT_PRESET = 'aseprite/import/preset'
 
 # HISTORY CONFIGS
 const DEFAULT_HISTORY_CONFIG_FILE_PATH = 'res://.aseprite_wizard_history'
-const HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/path'
+const HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/cache_file_path'
+const HISTORY_SINGLE_ENTRY_KEY = 'aseprite/wizard/history/keep_one_entry_per_source_file'
 
 # INTERFACE CONFIGS
 var _icon_arrow_down: Texture
@@ -217,6 +218,9 @@ func get_icon_arrow_right() -> Texture:
 # WIZARD HISTORY CONFIGS
 ######################################################
 
+func is_single_file_history() -> bool:
+	return ProjectSettings.get(HISTORY_SINGLE_ENTRY_KEY) == true
+
 
 func get_import_history() -> Array:
 	var history = []
@@ -250,7 +254,7 @@ func _get_history_file_path() -> String:
 	return p if p else DEFAULT_HISTORY_CONFIG_FILE_PATH
 
 
-func _initialize_project_cfg(key: String, default_value: String, type: int, hint: int):
+func _initialize_project_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE):
 	if not ProjectSettings.has_setting(key):
 		ProjectSettings.set(key, default_value)
 		ProjectSettings.set_initial_value(key, default_value)
@@ -264,8 +268,10 @@ func _initialize_project_cfg(key: String, default_value: String, type: int, hint
 
 func initialize_project_settings():
 	_initialize_project_cfg(HISTORY_CONFIG_FILE_CFG_KEY, DEFAULT_HISTORY_CONFIG_FILE_PATH, TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE)
+	_initialize_project_cfg(HISTORY_SINGLE_ENTRY_KEY, false, TYPE_BOOL)
 
 
 func clear_project_settings():
 	ProjectSettings.clear(HISTORY_CONFIG_FILE_CFG_KEY)
+	ProjectSettings.clear(HISTORY_SINGLE_ENTRY_KEY)
 	ProjectSettings.save()

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -29,7 +29,8 @@ const PIXEL_2D_PRESET_CFG = 'res://addons/AsepriteWizard/config/2d_pixel_preset.
 const ASEPRITE_PROJECT_SETTINGS_IMPORT_PRESET = 'aseprite/import/preset'
 
 # HISTORY CONFIGS
-const HISTORY_CONFIG_FILE_PATH = 'user://aseprite_wizard_history.cfg'
+const DEFAULT_HISTORY_CONFIG_FILE_PATH = 'res://.aseprite_wizard_history'
+const HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/path'
 
 # INTERFACE CONFIGS
 var _icon_arrow_down: Texture
@@ -212,13 +213,17 @@ func set_icon_arrow_right(icon: Texture) -> void:
 func get_icon_arrow_right() -> Texture:
 	return _icon_arrow_right
 
+#######################################################
+# WIZARD HISTORY CONFIGS
+######################################################
+
 
 func get_import_history() -> Dictionary:
-	# TODO bring HISTORY_CONFIG_FILE_PATH from settings
+	var history_path := _get_history_file_path()
 	var file_object = File.new()
-	if not file_object.file_exists(HISTORY_CONFIG_FILE_PATH):
+	if not file_object.file_exists(history_path):
 		return { "entries": [] }
-	file_object.open(HISTORY_CONFIG_FILE_PATH, File.READ)
+	file_object.open(history_path, File.READ)
 	var content =  parse_json(file_object.get_as_text())
 	file_object.close()
 	return content
@@ -226,6 +231,32 @@ func get_import_history() -> Dictionary:
 
 func save_import_history(history: Dictionary):
 	var file = File.new()
-	file.open(HISTORY_CONFIG_FILE_PATH, File.WRITE)
+	file.open(_get_history_file_path(), File.WRITE)
 	file.store_line(to_json(history))
 	file.close()
+
+
+func _get_history_file_path() -> String:
+	var p = ProjectSettings.get(HISTORY_CONFIG_FILE_CFG_KEY)
+	return p if p else DEFAULT_HISTORY_CONFIG_FILE_PATH
+
+
+func _initialize_project_cfg(key: String, default_value: String, type: int, hint: int):
+	if not ProjectSettings.has_setting(key):
+		ProjectSettings.set(key, default_value)
+		ProjectSettings.set_initial_value(key, default_value)
+		ProjectSettings.add_property_info({
+			"name": key,
+			"type": type,
+			"hint": hint,
+		})
+		ProjectSettings.save()
+
+
+func initialize_project_settings():
+	_initialize_project_cfg(HISTORY_CONFIG_FILE_CFG_KEY, DEFAULT_HISTORY_CONFIG_FILE_PATH, TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE)
+
+
+func clear_project_settings():
+	ProjectSettings.clear(HISTORY_CONFIG_FILE_CFG_KEY)
+	ProjectSettings.save()

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -26,11 +26,12 @@ func _enter_tree():
 	_setup_sprite_inspector_plugin()
 
 
-func _exit_tree():
+func disable_plugin():
 	_remove_menu_entries()
 	_remove_importer()
 	_remove_wizard_dock()
 	_remove_inspector_plugins()
+	config.clear_project_settings()
 
 
 func _load_config():
@@ -38,6 +39,7 @@ func _load_config():
 	config.load_config()
 	config.set_icon_arrow_down(editor_gui.get_icon("GuiTreeArrowDown", "EditorIcons"))
 	config.set_icon_arrow_right(editor_gui.get_icon("GuiTreeArrowRight", "EditorIcons"))
+	config.initialize_project_settings()
 
 
 func _setup_menu_entries():

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -2,7 +2,7 @@ tool
 extends EditorPlugin
 
 const ConfigDialog = preload('config/config_dialog.tscn')
-const WizardWindow = preload("animated_sprite/ASWizardWindow.tscn")
+const WizardWindow = preload("animated_sprite/ASWizardDockContainer.tscn")
 const ImportPlugin = preload("animated_sprite/import_plugin.gd")
 const AnimatedSpriteInspectorPlugin = preload("animated_sprite/inspector_plugin.gd")
 const SpriteInspectorPlugin = preload("animation_player/inspector_plugin.gd")
@@ -10,7 +10,7 @@ const menu_item_name = "Aseprite Spritesheet Wizard"
 const config_menu_item_name = "Aseprite Wizard Config"
 
 var config = preload("config/config.gd").new()
-var window: PanelContainer
+var window: TabContainer
 var config_window: PopupPanel
 var import_plugin : EditorImportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin

--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,10 @@ _global_script_class_icons={
 config/name="AsepriteWizard"
 config/icon="res://icon.png"
 
+[aseprite]
+
+wizard/history/cache_file_path="/home/vinicius/code/godot-aseprite-wizard/aseprite_wizard_history.cfg"
+
 [editor_plugins]
 
 enabled=PoolStringArray( "res://addons/AsepriteWizard/plugin.cfg" )

--- a/project.godot
+++ b/project.godot
@@ -19,7 +19,7 @@ config/icon="res://icon.png"
 
 [aseprite]
 
-wizard/history/cache_file_path="/home/vinicius/code/godot-aseprite-wizard/aseprite_wizard_history.cfg"
+wizard/history/cache_file_path=""
 
 [editor_plugins]
 


### PR DESCRIPTION
Adds a history tab to the wizard dock.
- This tab keeps track of all files imported via wizard
- Entries are saved to a version control friendly file
   - one entry per line to help with merge conflicts
   - Files imported from inside the project folder are saved with localised path (i.e res://file.aseprite)
- You can change the cache file location and some history behaviour in the project settings


![History tab](https://user-images.githubusercontent.com/4930052/181686799-b82755ec-8810-4d79-8111-aec29e8771f0.png)
