### PR TITLE
Store config in metadata

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -133,7 +133,7 @@ func _on_import_pressed():
 
 
 func _save_config():
-	wizard_config.save_config(sprite, {
+	wizard_config.save_config(sprite, config.is_use_metadata_enabled(), {
 		"source": _source,
 		"layer": _layer,
 		"op_exp": _options_title.pressed,

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -51,10 +51,10 @@ func _load_config(cfg):
 	_output_folder = cfg.get("o_folder", "")
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
 	_out_filename_field.text = cfg.get("o_name", "")
-	_visible_layers_field.pressed = cfg.get("only_visible", "") == "True"
+	_visible_layers_field.pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
 
-	_set_options_visible(cfg.get("op_exp", "false") == "True")
+	_set_options_visible(cfg.get("op_exp", false))
 
 
 func _load_default_config():

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -31,7 +31,7 @@ onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layer
 onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
 
 func _ready():
-	var cfg = wizard_config.decode(sprite.editor_description)
+	var cfg = wizard_config.load_config(sprite)
 
 	if cfg == null:
 		_load_default_config()
@@ -133,7 +133,7 @@ func _on_import_pressed():
 
 
 func _save_config():
-	sprite.editor_description = wizard_config.encode({
+	wizard_config.save_config(sprite, {
 		"source": _source,
 		"layer": _layer,
 		"op_exp": _options_title.pressed,

--- a/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
@@ -56,10 +56,10 @@ func _load_config(cfg):
 	_output_folder = cfg.get("o_folder", "")
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
 	_out_filename_field.text = cfg.get("o_name", "")
-	_visible_layers_field.pressed = cfg.get("only_visible", "") == "True"
+	_visible_layers_field.pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
 
-	_set_options_visible(cfg.get("op_exp", "false") == "True")
+	_set_options_visible(cfg.get("op_exp", false))
 
 
 func _load_default_config():

--- a/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
@@ -181,7 +181,7 @@ func _on_import_pressed():
 
 
 func _save_config():
-	wizard_config.save_config(sprite, {
+	wizard_config.save_config(sprite, config.is_use_metadata_enabled(), {
 		"player": _animation_player_path,
 		"source": _source,
 		"layer": _layer,

--- a/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
@@ -33,7 +33,7 @@ onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layer
 onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
 
 func _ready():
-	var cfg = wizard_config.decode(sprite.editor_description)
+	var cfg = wizard_config.load_config(sprite)
 
 	if cfg == null:
 		_load_default_config()
@@ -181,7 +181,7 @@ func _on_import_pressed():
 
 
 func _save_config():
-	sprite.editor_description = wizard_config.encode({
+	wizard_config.save_config(sprite, {
 		"player": _animation_player_path,
 		"source": _source,
 		"layer": _layer,

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -39,6 +39,9 @@ const _I_ONLY_VISIBLE_LAYERS_KEY = 'i_only_visible_layers'
 const _I_CUSTOM_NAME_KEY = 'i_custom_name'
 const _I_DO_NOT_CREATE_RES_KEY = 'i_disable_resource_creation'
 
+# export
+const _EXPORTER_ENABLE_KEY = 'aseprite/export/export_plugin/enable_export_metadata_removal'
+
 var _editor_settings: EditorSettings
 
 # INTERFACE SETTINGS
@@ -60,10 +63,13 @@ func get_command() -> String:
 #######################################################
 # PROJECT SETTINGS
 ######################################################
-
 func is_importer_enabled() -> bool:
 	return _get_project_setting(_IMPORTER_ENABLE_KEY, false)
-
+	
+	
+func is_exporter_enabled() -> bool:
+	return _get_project_setting(_EXPORTER_ENABLE_KEY, false)
+	
 
 func should_remove_source_files() -> bool:
 	return _get_project_setting(_REMOVE_SOURCE_FILES_KEY, true)
@@ -220,6 +226,8 @@ func initialize_project_settings():
 
 	_initialize_project_cfg(_REMOVE_SOURCE_FILES_KEY, true, TYPE_BOOL)
 	_initialize_project_cfg(_IMPORTER_ENABLE_KEY, false, TYPE_BOOL)
+	
+	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, false, TYPE_BOOL)
 
 	_initialize_project_cfg(_HISTORY_CONFIG_FILE_CFG_KEY, _DEFAULT_HISTORY_CONFIG_FILE_PATH, TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE)
 	_initialize_project_cfg(_HISTORY_SINGLE_ENTRY_KEY, false, TYPE_BOOL)
@@ -239,6 +247,7 @@ func clear_project_settings():
 		_IMPORT_PRESET_KEY,
 		_REMOVE_SOURCE_FILES_KEY,
 		_IMPORTER_ENABLE_KEY,
+		_EXPORTER_ENABLE_KEY,
 		_HISTORY_CONFIG_FILE_CFG_KEY,
 		_HISTORY_SINGLE_ENTRY_KEY
 	]

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -12,6 +12,7 @@ const _DEFAULT_EXCLUSION_PATTERN_KEY = 'aseprite/animation/layers/exclusion_patt
 const _DEFAULT_LOOP_EX_PREFIX = '_'
 const _LOOP_ENABLED = 'aseprite/animation/loop/enabled'
 const _LOOP_EXCEPTION_PREFIX = 'aseprite/animation/loop/exception_prefix'
+const _USE_METADATA = 'aseprite/animation/storage/use_metadata'
 
 # custom preset
 const _IMPORT_PRESET_ENABLED = 'aseprite/import/preset/enable_custom_preset'
@@ -74,6 +75,9 @@ func is_default_animation_loop_enabled() -> bool:
 
 func get_animation_loop_exception_prefix() -> String:
 	return _get_project_setting(_LOOP_EXCEPTION_PREFIX, _DEFAULT_LOOP_EX_PREFIX)
+	
+func is_use_metadata_enabled() -> bool:
+	return _get_project_setting(_USE_METADATA, false)
 
 
 func get_default_exclusion_pattern() -> String:
@@ -210,6 +214,7 @@ func initialize_project_settings():
 	_initialize_project_cfg(_DEFAULT_EXCLUSION_PATTERN_KEY, "", TYPE_STRING)
 	_initialize_project_cfg(_LOOP_ENABLED, true, TYPE_BOOL)
 	_initialize_project_cfg(_LOOP_EXCEPTION_PREFIX, _DEFAULT_LOOP_EX_PREFIX, TYPE_STRING)
+	_initialize_project_cfg(_USE_METADATA, false, TYPE_BOOL)
 
 	_initialize_project_cfg(_IMPORT_PRESET_ENABLED, false, TYPE_BOOL)
 
@@ -229,6 +234,7 @@ func clear_project_settings():
 		_DEFAULT_EXCLUSION_PATTERN_KEY,
 		_LOOP_ENABLED,
 		_LOOP_EXCEPTION_PREFIX,
+		_USE_METADATA,
 		_IMPORT_PRESET_ENABLED,
 		_IMPORT_PRESET_KEY,
 		_REMOVE_SOURCE_FILES_KEY,

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -40,7 +40,7 @@ const _I_CUSTOM_NAME_KEY = 'i_custom_name'
 const _I_DO_NOT_CREATE_RES_KEY = 'i_disable_resource_creation'
 
 # export
-const _EXPORTER_ENABLE_KEY = 'aseprite/export/export_plugin/enable_export_metadata_removal'
+const _EXPORTER_ENABLE_KEY = 'aseprite/animation/storage/enable_metadata_removal_on_export'
 
 var _editor_settings: EditorSettings
 

--- a/addons/AsepriteWizard/config/wizard_config.gd
+++ b/addons/AsepriteWizard/config/wizard_config.gd
@@ -23,7 +23,21 @@ static func decode(string: String):
 	for c in cfg:
 		var parts = c.split(SEPARATOR, 1)
 		if parts.size() == 2:
-			config[parts[0].strip_edges()] = parts[1].strip_edges()
+			var key = parts[0].strip_edges()
+			var value = parts[1].strip_edges()
+			
+			#Convert bool properties
+			if key == "only_visible" or key == "op_exp":
+				match value:
+					"True":
+						config[key] = true
+					"False":
+						config[key] = false
+					_:
+						config[key] = false
+			else:
+				config[key] = value
+				
 	return config
 
 

--- a/addons/AsepriteWizard/config/wizard_config.gd
+++ b/addons/AsepriteWizard/config/wizard_config.gd
@@ -57,10 +57,13 @@ static func load_config(node:Node):
 		
 	return decode(node.editor_description)
 	
-static func save_config(node:Node, cfg:Dictionary):
-	node.set_meta(WIZARD_CONFIG_META_NAME, cfg)
-	
-	#Delete config from editor_description
-	var decoded = _decode_base64(node.editor_description)
-	if  _is_wizard_config(decoded):
-		node.editor_description = ""
+static func save_config(node:Node, use_metadata:bool, cfg:Dictionary):
+	if use_metadata:
+		node.set_meta(WIZARD_CONFIG_META_NAME, cfg)
+		
+		#Delete config from editor_description
+		var decoded = _decode_base64(node.editor_description)
+		if  _is_wizard_config(decoded):
+			node.editor_description = ""
+	else:
+		node.editor_description = encode(cfg)

--- a/addons/AsepriteWizard/config/wizard_config.gd
+++ b/addons/AsepriteWizard/config/wizard_config.gd
@@ -1,6 +1,7 @@
 tool
 extends Reference
 
+const WIZARD_CONFIG_META_NAME = "_aseprite_wizard_config_"
 const WIZARD_CONFIG_MARKER = "aseprite_wizard_config"
 const SEPARATOR = "|="
 
@@ -50,3 +51,16 @@ static func _decode_base64(string: String):
 static func _is_wizard_config(cfg) -> bool:
 	return cfg != null and cfg.begins_with(WIZARD_CONFIG_MARKER)
 
+static func load_config(node:Node):
+	if node.has_meta(WIZARD_CONFIG_META_NAME):
+		return node.get_meta(WIZARD_CONFIG_META_NAME)
+		
+	return decode(node.editor_description)
+	
+static func save_config(node:Node, cfg:Dictionary):
+	node.set_meta(WIZARD_CONFIG_META_NAME, cfg)
+	
+	#Delete config from editor_description
+	var decoded = _decode_base64(node.editor_description)
+	if  _is_wizard_config(decoded):
+		node.editor_description = ""

--- a/addons/AsepriteWizard/export/metadata_export_plugin.gd
+++ b/addons/AsepriteWizard/export/metadata_export_plugin.gd
@@ -1,0 +1,58 @@
+extends EditorExportPlugin
+
+const wizard_config = preload("../config/wizard_config.gd")
+
+func _export_file(path: String, type: String, features: PoolStringArray) -> void:
+	if type != "PackedScene": return
+
+	var scene : PackedScene =  ResourceLoader.load(path, type, true)
+	var scene_changed := false
+	var root_node := scene.instance(PackedScene.GEN_EDIT_STATE_INSTANCE)
+	var nodes := [root_node]
+
+	#remove metadata from scene
+	while not nodes.empty():
+		var node : Node = nodes.pop_front()
+
+		for child in node.get_children():
+			nodes.push_back(child)
+
+		if _remove_meta(node, path):
+			scene_changed = true
+
+	#save scene if changed
+	if scene_changed:
+		var filtered_scene := PackedScene.new()
+		if filtered_scene.pack(root_node) != OK:
+			print("Error updating scene")
+			return
+
+		var content := _get_scene_content(path, filtered_scene)
+		
+		add_file(path, content, true)
+
+	root_node.free()
+	
+func _remove_meta(node:Node, path: String) -> bool:
+	if node.has_meta(wizard_config.WIZARD_CONFIG_META_NAME):
+		node.remove_meta(wizard_config.WIZARD_CONFIG_META_NAME)
+		print("Removed metadata from scene %s" % path)
+		return true
+		
+	return false
+	
+func _get_scene_content(path:String, scene:PackedScene) -> PoolByteArray:
+	var tmp_path = OS.get_cache_dir()  + "tmp_scene." + path.get_extension()
+	ResourceSaver.save(tmp_path, scene)
+
+	var tmp_file = File.new()
+	tmp_file.open(tmp_path,File.READ)
+	var content : PoolByteArray = tmp_file.get_buffer(tmp_file.get_len())
+	tmp_file.close()
+	
+	var dir = Directory.new()
+
+	if dir.file_exists(tmp_path):
+		dir.remove(tmp_path)
+
+	return content

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -4,6 +4,7 @@ extends EditorPlugin
 const ConfigDialog = preload('config/config_dialog.tscn')
 const WizardWindow = preload("animated_sprite/docks/as_wizard_dock_container.tscn")
 const ImportPlugin = preload("animated_sprite/import_plugin.gd")
+const ExportPlugin = preload("export/metadata_export_plugin.gd")
 const AnimatedSpriteInspectorPlugin = preload("animated_sprite/inspector_plugin.gd")
 const SpriteInspectorPlugin = preload("animation_player/inspector_plugin.gd")
 const menu_item_name = "Aseprite Spritesheet Wizard"
@@ -13,16 +14,19 @@ var config = preload("config/config.gd").new()
 var window: TabContainer
 var config_window: PopupPanel
 var import_plugin : EditorImportPlugin
+var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
 
 var _importer_enabled = false
+var _exporter_enabled = false
 
 
 func _enter_tree():
 	_load_config()
 	_setup_menu_entries()
 	_setup_importer()
+	_setup_exporter()
 	_configure_preset()
 	_setup_animated_sprite_inspector_plugin()
 	_setup_sprite_inspector_plugin()
@@ -31,6 +35,7 @@ func _enter_tree():
 func disable_plugin():
 	_remove_menu_entries()
 	_remove_importer()
+	_remove_exporter()
 	_remove_wizard_dock()
 	_remove_inspector_plugins()
 	config.clear_project_settings()
@@ -73,6 +78,19 @@ func _remove_importer():
 	if _importer_enabled:
 		remove_import_plugin(import_plugin)
 		_importer_enabled = false
+		
+
+func _setup_exporter():
+	if config.is_exporter_enabled():
+		export_plugin = ExportPlugin.new()
+		add_export_plugin(export_plugin)
+		_exporter_enabled = true
+
+
+func _remove_exporter():
+	if _exporter_enabled:
+		remove_export_plugin(export_plugin)
+		_exporter_enabled = false
 
 
 func _setup_sprite_inspector_plugin():


### PR DESCRIPTION
This PR is for #61 

I have made changes so it stores the config in object metadata instead of using the `editor_description` property.

It can still load config from the `editor_description` property if it exists. But if import is run again it will store the config in metadata and clear the `editor_description` property, but only if it is containing aseprite-wizard config.

As I previously mentioned in issue #61 this data does get included in the exported game.  I did workout how to make it so it could remove this data on export but have not included it yet because I think there should be some discussion bout this. Some talking points:

* Should it be a feature you can toggle on/off.
* What export performance implications are there.