### PR TITLE
Add meta tracks and 3D node supprot

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -6,7 +6,7 @@ const result_code = preload("../../config/result_codes.gd")
 var sprite_frames_creator = preload("../sprite_frames_creator.gd").new()
 
 var scene: Node
-var sprite: AnimatedSprite
+var sprite: Node
 
 var config
 var file_system: EditorFileSystem

--- a/addons/AsepriteWizard/animated_sprite/inspector_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/inspector_plugin.gd
@@ -5,10 +5,10 @@ const InspectorDock = preload("./docks/animated_sprite_inspector_dock.tscn")
 
 var config
 var file_system: EditorFileSystem
-var _sprite: AnimatedSprite
+var _sprite: Node
 
 func can_handle(object):
-	return object is AnimatedSprite
+	return object is AnimatedSprite || object is AnimatedSprite3D
 
 
 func parse_begin(object):

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -29,7 +29,7 @@ func _is_loop_config_enabled() -> String:
 	return _config.is_default_animation_loop_enabled()
 
 
-func create_animations(sprite: AnimatedSprite, options: Dictionary):
+func create_animations(sprite: Node, options: Dictionary):
 	if not _aseprite.test_command():
 		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
 
@@ -49,7 +49,7 @@ func create_animations(sprite: AnimatedSprite, options: Dictionary):
 		printerr(result_code.get_error_message(result))
 
 
-func _create_animations_from_file(sprite: AnimatedSprite, options: Dictionary):
+func _create_animations_from_file(sprite: Node, options: Dictionary):
 	var output
 
 	if options.get("layer", "") == "":

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -170,6 +170,7 @@ func _import(data, animated_sprite = null) -> int:
 		return result_code.ERR_INVALID_ASEPRITE_SPRITESHEET
 
 	var texture = _parse_texture_path(sprite_sheet)
+	texture.take_over_path(sprite_sheet)
 
 	var resource = _create_sprite_frames_with_animations(content, texture)
 

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -80,6 +80,7 @@ func _import(sprite: Node, player: AnimationPlayer, data: Dictionary):
 
 func _load_texture(sprite: Node, sprite_sheet: String, content: Dictionary):
 	var texture = ResourceLoader.load(sprite_sheet, 'Image', true)
+	texture.take_over_path(sprite_sheet)
 	sprite.texture = texture
 
 	if content.frames.empty():
@@ -115,8 +116,9 @@ func _add_animation_frames(sprite: Node, player: AnimationPlayer, anim_name: Str
 		player.add_animation(animation_name, Animation.new())
 
 	var animation = player.get_animation(animation_name)
-	var track = _get_frame_track_path(player, sprite)
-	var track_index = _create_frame_track(sprite, animation, track)
+	_create_meta_tracks(sprite, player, animation)
+	var frame_track = _get_property_track_path(player, sprite, "frame")
+	var frame_track_index = _create_track(sprite, animation, frame_track)
 
 	if direction == 'reverse':
 		frames.invert()
@@ -125,7 +127,7 @@ func _add_animation_frames(sprite: Node, player: AnimationPlayer, anim_name: Str
 
 	for frame in frames:
 		var frame_index = _calculate_frame_index(sprite, frame)
-		animation.track_insert_key(track_index, animation_length, frame_index)
+		animation.track_insert_key(frame_track_index, animation_length, frame_index)
 		animation_length += frame.duration / 1000
 
 	if direction == 'pingpong':
@@ -136,7 +138,7 @@ func _add_animation_frames(sprite: Node, player: AnimationPlayer, anim_name: Str
 
 		for frame in frames:
 			var frame_index = _calculate_frame_index(sprite, frame)
-			animation.track_insert_key(track_index, animation_length, frame_index)
+			animation.track_insert_key(frame_track_index, animation_length, frame_index)
 			animation_length += frame.duration / 1000
 
 	animation.length = animation_length
@@ -145,13 +147,31 @@ func _add_animation_frames(sprite: Node, player: AnimationPlayer, anim_name: Str
 	return result_code.SUCCESS
 
 
+func _create_meta_tracks(sprite: Node, player: AnimationPlayer, animation: Animation):
+	var texture_track = _get_property_track_path(player, sprite, "texture")
+	var texture_track_index = _create_track(sprite, animation, texture_track)
+	animation.track_insert_key(texture_track_index, 0, sprite.texture)
+
+	var hframes_track = _get_property_track_path(player, sprite, "hframes")
+	var hframes_track_index = _create_track(sprite, animation, hframes_track)
+	animation.track_insert_key(hframes_track_index, 0, sprite.hframes)
+
+	var vframes_track = _get_property_track_path(player, sprite, "vframes")
+	var vframes_track_index = _create_track(sprite, animation, vframes_track)
+	animation.track_insert_key(vframes_track_index, 0, sprite.vframes)
+
+	var visible_track = _get_property_track_path(player, sprite, "visible")
+	var visible_track_index = _create_track(sprite, animation, visible_track)
+	animation.track_insert_key(visible_track_index, 0, true)
+
+
 func _calculate_frame_index(sprite: Node, frame: Dictionary) -> int:
 	var column = floor(frame.frame.x * sprite.hframes / sprite.texture.get_width())
 	var row = floor(frame.frame.y * sprite.vframes / sprite.texture.get_height())
 	return (row * sprite.hframes) + column
 
 
-func _create_frame_track(sprite: Node, animation: Animation, track: String):
+func _create_track(sprite: Node, animation: Animation, track: String):
 	var track_index = animation.find_track(track)
 
 	if track_index != -1:
@@ -165,16 +185,15 @@ func _create_frame_track(sprite: Node, animation: Animation, track: String):
 	return track_index
 
 
-func _get_frame_track_path(player: AnimationPlayer, sprite: Node):
-	var node_path = player.get_node(player.root_node).get_path_to(sprite)
-	return "%s:frame" % node_path
+func _get_property_track_path(player: AnimationPlayer, sprite: Node, prop: String) -> String:
+		var node_path = player.get_node(player.root_node).get_path_to(sprite)
+		return "%s:%s" % [node_path, prop]
 
 
 func _cleanup_animations(sprite: Node, player: AnimationPlayer, content: Dictionary):
 	if not (content.meta.has("frameTags") and content.meta.frameTags.size() > 0):
 		return result_code.SUCCESS
 
-	var track = _get_frame_track_path(player, sprite)
 	var tags = ["RESET"]
 	for t in content.meta.frameTags:
 		var a = t.name
@@ -182,20 +201,46 @@ func _cleanup_animations(sprite: Node, player: AnimationPlayer, content: Diction
 			a = a.substr(_config.get_animation_loop_exception_prefix().length())
 		tags.push_back(a)
 
-	for a in player.get_animation_list():
-		if tags.has(a):
-			continue
+	var root_node := player.get_node(player.root_node)
+	var all_animations := player.get_animation_list()
+	var all_sprite_nodes := []
+	var animation_sprites := {}
 
-		var animation = player.get_animation(a)
+	for a in all_animations:
+		var animation := player.get_animation(a)
+		var sprite_nodes := []
 
-		if animation.get_track_count() != 1:
-			var t = animation.find_track(track)
-			if t != -1:
-				animation.remove_track(t)
-			continue
+		for track_idx in animation.get_track_count():
+			var raw_path := animation.track_get_path(track_idx)
+			if "visible" in raw_path as String:
+				continue
 
-		if animation.find_track(track) != -1:
-			player.remove_animation(a)
+			var path := _remove_properties_from_path(raw_path)
+			var sprite_node := root_node.get_node(path)
+
+			if !(sprite_node is Sprite || sprite_node is Sprite3D):
+				continue
+
+			if sprite_nodes.has(sprite_node):
+				continue
+			sprite_nodes.append(sprite_node)
+
+		animation_sprites[animation] = sprite_nodes
+		for sn in sprite_nodes:
+			if all_sprite_nodes.has(sn):
+				continue
+			all_sprite_nodes.append(sn)
+
+	for animation in animation_sprites:
+		var sprite_nodes : Array = animation_sprites[animation]
+		for node in all_sprite_nodes:
+			if sprite_nodes.has(node):
+				continue
+			var visible_track = _get_property_track_path(player, node, "visible")
+			if animation.find_track(visible_track) != -1:
+				continue
+			var visible_track_index = _create_track(node, animation, visible_track)
+			animation.track_insert_key(visible_track_index, 0, false)
 
 	return result_code.SUCCESS
 
@@ -207,3 +252,13 @@ func _scan_filesystem():
 
 func list_layers(file: String, only_visibles = false) -> Array:
 	return _aseprite.list_layers(file, only_visibles)
+
+
+func _remove_properties_from_path(path: NodePath) -> NodePath:
+	var string_path := path as String
+	if !(":" in string_path):
+		return string_path as NodePath
+
+	var property_path := path.get_concatenated_subnames() as String
+	string_path.erase((string_path).length() - property_path.length() - 1, property_path.length() + 1)
+	return string_path as NodePath

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -12,7 +12,7 @@ func init(config, editor_file_system: EditorFileSystem = null):
 	_aseprite.init(config)
 
 
-func create_animations(sprite: Sprite, player: AnimationPlayer, options: Dictionary):
+func create_animations(sprite: Node, player: AnimationPlayer, options: Dictionary):
 	if not _aseprite.test_command():
 		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
 
@@ -31,7 +31,7 @@ func create_animations(sprite: Sprite, player: AnimationPlayer, options: Diction
 		printerr(result_code.get_error_message(result))
 
 
-func _create_animations_from_file(sprite: Sprite, player: AnimationPlayer, options: Dictionary):
+func _create_animations_from_file(sprite: Node, player: AnimationPlayer, options: Dictionary):
 	var output
 
 	if options.get("layer", "") == "":
@@ -56,7 +56,7 @@ func _create_animations_from_file(sprite: Sprite, player: AnimationPlayer, optio
 	return result
 
 
-func _import(sprite: Sprite, player: AnimationPlayer, data: Dictionary):
+func _import(sprite: Node, player: AnimationPlayer, data: Dictionary):
 	var source_file = data.data_file
 	var sprite_sheet = data.sprite_sheet
 
@@ -78,7 +78,7 @@ func _import(sprite: Sprite, player: AnimationPlayer, data: Dictionary):
 	return _cleanup_animations(sprite, player, content)
 
 
-func _load_texture(sprite: Sprite, sprite_sheet: String, content: Dictionary):
+func _load_texture(sprite: Node, sprite_sheet: String, content: Dictionary):
 	var texture = ResourceLoader.load(sprite_sheet, 'Image', true)
 	sprite.texture = texture
 
@@ -89,7 +89,7 @@ func _load_texture(sprite: Sprite, sprite_sheet: String, content: Dictionary):
 	sprite.vframes = content.meta.size.h / content.frames[0].sourceSize.h
 
 
-func _configure_animations(sprite: Sprite, player: AnimationPlayer, content: Dictionary):
+func _configure_animations(sprite: Node, player: AnimationPlayer, content: Dictionary):
 	var frames = _aseprite.get_content_frames(content)
 	if content.meta.has("frameTags") and content.meta.frameTags.size() > 0:
 		var result = result_code.SUCCESS
@@ -103,7 +103,7 @@ func _configure_animations(sprite: Sprite, player: AnimationPlayer, content: Dic
 		return _add_animation_frames(sprite, player, "default", frames)
 
 
-func _add_animation_frames(sprite: Sprite, player: AnimationPlayer, anim_name: String, frames: Array, direction = 'forward'):
+func _add_animation_frames(sprite: Node, player: AnimationPlayer, anim_name: String, frames: Array, direction = 'forward'):
 	var animation_name = anim_name
 	var is_loopable = _config.is_default_animation_loop_enabled()
 
@@ -145,13 +145,13 @@ func _add_animation_frames(sprite: Sprite, player: AnimationPlayer, anim_name: S
 	return result_code.SUCCESS
 
 
-func _calculate_frame_index(sprite: Sprite, frame: Dictionary) -> int:
+func _calculate_frame_index(sprite: Node, frame: Dictionary) -> int:
 	var column = floor(frame.frame.x * sprite.hframes / sprite.texture.get_width())
 	var row = floor(frame.frame.y * sprite.vframes / sprite.texture.get_height())
 	return (row * sprite.hframes) + column
 
 
-func _create_frame_track(sprite: Sprite, animation: Animation, track: String):
+func _create_frame_track(sprite: Node, animation: Animation, track: String):
 	var track_index = animation.find_track(track)
 
 	if track_index != -1:
@@ -165,12 +165,12 @@ func _create_frame_track(sprite: Sprite, animation: Animation, track: String):
 	return track_index
 
 
-func _get_frame_track_path(player: AnimationPlayer, sprite: Sprite):
+func _get_frame_track_path(player: AnimationPlayer, sprite: Node):
 	var node_path = player.get_node(player.root_node).get_path_to(sprite)
 	return "%s:frame" % node_path
 
 
-func _cleanup_animations(sprite: Sprite, player: AnimationPlayer, content: Dictionary):
+func _cleanup_animations(sprite: Node, player: AnimationPlayer, content: Dictionary):
 	if not (content.meta.has("frameTags") and content.meta.frameTags.size() > 0):
 		return result_code.SUCCESS
 

--- a/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd
@@ -6,7 +6,7 @@ const result_code = preload("../../config/result_codes.gd")
 var animation_creator = preload("../animation_creator.gd").new()
 
 var scene: Node
-var sprite: Sprite
+var sprite: Node
 
 var config
 var file_system: EditorFileSystem

--- a/addons/AsepriteWizard/animation_player/inspector_plugin.gd
+++ b/addons/AsepriteWizard/animation_player/inspector_plugin.gd
@@ -5,10 +5,10 @@ const InspectorDock = preload("./docks/sprite_inspector_dock.tscn")
 
 var config
 var file_system: EditorFileSystem
-var _sprite: Sprite
+var _sprite: Node
 
 func can_handle(object):
-	return object is Sprite
+	return object is Sprite || object is Sprite3D
 
 
 func parse_begin(object):

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -59,8 +59,8 @@ func export_layers(file_name: String, output_folder: String, options: Dictionary
 
 
 func export_layer(file_name: String, layer_name: String, output_folder: String, options: Dictionary) -> Dictionary:
-	var output_prefix = options.get('output_filename', "")
-	var output_dir = output_folder.replace("res://", "./")
+	var output_prefix = options.get('output_filename', "").strip_edges()
+	var output_dir = output_folder.replace("res://", "./").strip_edges()
 	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, layer_name]
 	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, layer_name]
 	var output = []
@@ -129,8 +129,12 @@ func list_layers(file_name: String, only_visible = false) -> Array:
 
 	if output.empty():
 		return output
-
-	return output[0].split('\n')
+	
+	var raw = output[0].split('\n')
+	var sanitized = []
+	for s in raw:
+		sanitized.append(s.strip_edges())
+	return sanitized
 
 
 func _export_command_common_arguments(source_name: String, data_path: String, spritesheet_path: String) -> Array:


### PR DESCRIPTION
This PR does a couple of things:

1. It adds some simple sanitization on layer and file names by removing whitespaces, I've run into a couple of issues where Windows went berserk over strange whitespaces. This should solve #59 
2. It adds support for Sprite3D and AnimatedSprite3D, which is implemented by just changing the `can_handle` method to behave properly. This closes #53.
3. When importing spritesheets it calls `take_over_path`  on the Texture, which signals to Godot that this Resource that is currently in memory actually has a filesystem backing and that it should be respected. This removes issues related to Godot incorrectly thinking that the same resource is imported multiple times, that can happen when importing and updating a lot of animations, as well as `editor/import/resource_importer_texture.cpp:96 - Condition "err != OK" is true. Continuing.` mentioned in #53
![aseprite_proper_path](https://user-images.githubusercontent.com/2500134/188263762-a6529c1d-5930-4a2c-ad32-b791c311749a.png)
![image](https://user-images.githubusercontent.com/2500134/188263770-41596717-68e3-457b-96e4-bdbcd2be48d6.png)
4. It adds additional tracks to the AnimationPlayer. Specifically it adds tracks for the `texture`, `hframes`, `vframes` and `visible` properties. The purpose of this is to allow users to import animations from multiple .aseprite files into the same AnimationPlayer node. Sprite nodes that are not used by an animation will be automatically set to invisible, which enables easier separation of multiple animations into layers. All of this makes it much easier to use AsepriteWizard with the `AnimationTree` node, as it only supports having one AnimationPlayer attached. This should also help with #32 as users can now separate massive .aseprite files into multiple .aseprite files and just use those instead.
![aseprite_example](https://user-images.githubusercontent.com/2500134/188263912-75143686-843c-4048-931c-4a2c0b294bb5.gif)


I've been using these changes for quite a long time now in my project, but that also means I could be "use case blind" and not see issues or potential specifics to my project. Please test the behavior yourself and tell me what you think/and what potential improvements there are.