### PR TITLE
Add TextureRect support and Visible track generation config

### DIFF
--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -48,7 +48,7 @@ func _create_animations_from_file(target_node: Node, player: AnimationPlayer, op
 
 	yield(_scan_filesystem(), "completed")
 
-	var result = _import(target_node, player, output)
+	var result = _import(target_node, player, output, options)
 
 	if _config.should_remove_source_files():
 		var dir = Directory.new()
@@ -57,7 +57,7 @@ func _create_animations_from_file(target_node: Node, player: AnimationPlayer, op
 	return result
 
 
-func _import(target_node: Node, player: AnimationPlayer, data: Dictionary):
+func _import(target_node: Node, player: AnimationPlayer, data: Dictionary, options: Dictionary):
 	var source_file = data.data_file
 	var sprite_sheet = data.sprite_sheet
 
@@ -78,7 +78,7 @@ func _import(target_node: Node, player: AnimationPlayer, data: Dictionary):
 	if result != result_code.SUCCESS:
 		return result
 
-	return _cleanup_animations(target_node, player, content)
+	return _cleanup_animations(target_node, player, content, options)
 	
 
 func _load_texture(sprite_sheet: String) -> Texture:
@@ -163,7 +163,7 @@ func _get_property_track_path(player: AnimationPlayer, target_node: Node, prop: 
 		return "%s:%s" % [node_path, prop]
 
 
-func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Dictionary):
+func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Dictionary, options: Dictionary):
 	if not (content.meta.has("frameTags") and content.meta.frameTags.size() > 0):
 		return result_code.SUCCESS
 
@@ -174,6 +174,13 @@ func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Di
 			a = a.substr(_config.get_animation_loop_exception_prefix().length())
 		tags.push_back(a)
 
+	if options.get("cleanup_hide_unused_nodes", false):
+		_hide_unused_nodes(target_node, player, content)	
+
+	return result_code.SUCCESS
+
+
+func _hide_unused_nodes(target_node: Node, player: AnimationPlayer, content: Dictionary):
 	var root_node := player.get_node(player.root_node)
 	var all_animations := player.get_animation_list()
 	var all_sprite_nodes := []
@@ -214,8 +221,6 @@ func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Di
 				continue
 			var visible_track_index = _create_track(node, animation, visible_track)
 			animation.track_insert_key(visible_track_index, 0, false)
-
-	return result_code.SUCCESS
 
 
 func _scan_filesystem():

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
@@ -3,10 +3,15 @@ extends PanelContainer
 
 const wizard_config = preload("../../config/wizard_config.gd")
 const result_code = preload("../../config/result_codes.gd")
-var animation_creator = preload("../animation_creator.gd").new()
+
+const AnimationCreator = preload("../animation_creator.gd")
+const SpriteAnimationCreator = preload("../sprite_animation_creator.gd")
+const TextureRectAnimationCreator = preload("../texture_rect_animation_creator.gd")
+
+var animation_creator: AnimationCreator
 
 var scene: Node
-var sprite: Node
+var target_node: Node
 
 var config
 var file_system: EditorFileSystem
@@ -33,12 +38,17 @@ onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layer
 onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
 
 func _ready():
-	var cfg = wizard_config.decode(sprite.editor_description)
+	var cfg = wizard_config.decode(target_node.editor_description)
 
 	if cfg == null:
 		_load_default_config()
 	else:
 		_load_config(cfg)
+
+	if target_node is Sprite || target_node is Sprite3D:
+		animation_creator = SpriteAnimationCreator.new()
+	if target_node is TextureRect:
+		animation_creator = TextureRectAnimationCreator.new()		
 
 	animation_creator.init(config, file_system)
 
@@ -176,12 +186,12 @@ func _on_import_pressed():
 
 	_save_config()
 
-	animation_creator.create_animations(sprite, root.get_node(_animation_player_path), options)
+	animation_creator.create_animations(target_node, root.get_node(_animation_player_path), options)
 	_importing = false
 
 
 func _save_config():
-	sprite.editor_description = wizard_config.encode({
+	target_node.editor_description = wizard_config.encode({
 		"player": _animation_player_path,
 		"source": _source,
 		"layer": _layer,

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
@@ -147,25 +147,25 @@ align = 0
 [node name="options" type="VBoxContainer" parent="margin/VBoxContainer"]
 visible = false
 margin_top = 120.0
-margin_right = 198.0
-margin_bottom = 240.0
+margin_right = 209.0
+margin_bottom = 284.0
 
 [node name="out_folder" type="HBoxContainer" parent="margin/VBoxContainer/options"]
-margin_right = 198.0
+margin_right = 209.0
 margin_bottom = 20.0
 hint_tooltip = "Location where the spritesheet file should be saved."
 
 [node name="Label" type="Label" parent="margin/VBoxContainer/options/out_folder"]
 margin_top = 3.0
-margin_right = 97.0
+margin_right = 102.0
 margin_bottom = 17.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Output folder"
 
 [node name="button" type="Button" parent="margin/VBoxContainer/options/out_folder"]
-margin_left = 101.0
-margin_right = 198.0
+margin_left = 106.0
+margin_right = 209.0
 margin_bottom = 20.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
@@ -174,7 +174,7 @@ clip_text = true
 
 [node name="out_filename" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_top = 24.0
-margin_right = 198.0
+margin_right = 209.0
 margin_bottom = 48.0
 hint_tooltip = "Base filename for spritesheet. In case the layer option is used, this works as a prefix to the layer name."
 
@@ -188,35 +188,35 @@ text = "Output file name"
 
 [node name="LineEdit" type="LineEdit" parent="margin/VBoxContainer/options/out_filename"]
 margin_left = 113.0
-margin_right = 198.0
+margin_right = 209.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
 [node name="ex_pattern" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_top = 52.0
-margin_right = 198.0
+margin_right = 209.0
 margin_bottom = 76.0
 hint_tooltip = "Exclude layers with name matching this pattern (regex)."
 
 [node name="Label" type="Label" parent="margin/VBoxContainer/options/ex_pattern"]
 margin_top = 5.0
-margin_right = 99.0
+margin_right = 102.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Exclude pattern"
 
 [node name="LineEdit" type="LineEdit" parent="margin/VBoxContainer/options/ex_pattern"]
-margin_left = 103.0
-margin_right = 198.0
+margin_left = 106.0
+margin_right = 209.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
 [node name="visible_layers" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 margin_top = 80.0
-margin_right = 198.0
+margin_right = 209.0
 margin_bottom = 120.0
 hint_tooltip = "If active, layers not visible in the source file won't be included in the final image."
 
@@ -230,7 +230,28 @@ text = "Only visible layers"
 
 [node name="CheckButton" type="CheckButton" parent="margin/VBoxContainer/options/visible_layers"]
 margin_left = 122.0
-margin_right = 198.0
+margin_right = 209.0
+margin_bottom = 40.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+
+[node name="auto_visible_track" type="HBoxContainer" parent="margin/VBoxContainer/options"]
+margin_top = 124.0
+margin_right = 209.0
+margin_bottom = 164.0
+hint_tooltip = "If active, it will automatically determine unused Sprite and Sprite3D nodes in each animation and hide them."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/options/auto_visible_track"]
+margin_top = 13.0
+margin_right = 129.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Hide unused sprites"
+
+[node name="CheckButton" type="CheckButton" parent="margin/VBoxContainer/options/auto_visible_track"]
+margin_left = 133.0
+margin_right = 209.0
 margin_bottom = 40.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://addons/AsepriteWizard/animation_player/docks/sprite_inspector_dock.gd" type="Script" id=1]
+[ext_resource path="res://addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd" type="Script" id=1]
 
 [sub_resource type="StyleBoxEmpty" id=1]
 

--- a/addons/AsepriteWizard/animation_player/inspector_plugin.gd
+++ b/addons/AsepriteWizard/animation_player/inspector_plugin.gd
@@ -1,23 +1,23 @@
 tool
 extends EditorInspectorPlugin
 
-const InspectorDock = preload("./docks/sprite_inspector_dock.tscn")
+const InspectorDock = preload("./docks/animation_player_inspector_dock.tscn")
 
 var config
 var file_system: EditorFileSystem
-var _sprite: Node
+var _target_node: Node
 
 func can_handle(object):
-	return object is Sprite || object is Sprite3D
+	return object is Sprite || object is Sprite3D || object is TextureRect
 
 
 func parse_begin(object):
-	_sprite = object
+	_target_node = object
 
 
 func parse_end():
 	var dock = InspectorDock.instance()
-	dock.sprite = _sprite
+	dock.target_node = _target_node
 	dock.config = config
 	dock.file_system = file_system
 	add_custom_control(dock)

--- a/addons/AsepriteWizard/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/sprite_animation_creator.gd
@@ -1,0 +1,45 @@
+extends "animation_creator.gd"
+
+
+func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
+	var texture = _load_texture(sprite_sheet)
+	sprite.texture = texture
+
+	if content.frames.empty():
+		return
+
+	sprite.hframes = content.meta.size.w / content.frames[0].sourceSize.w
+	sprite.vframes = content.meta.size.h / content.frames[0].sourceSize.h
+
+
+func _get_frame_property() -> String:
+	return "frame"
+
+
+func _create_meta_tracks(sprite: Node, player: AnimationPlayer, animation: Animation):
+	var texture_track = _get_property_track_path(player, sprite, "texture")
+	var texture_track_index = _create_track(sprite, animation, texture_track)
+	animation.track_insert_key(texture_track_index, 0, sprite.texture)
+
+	var hframes_track = _get_property_track_path(player, sprite, "hframes")
+	var hframes_track_index = _create_track(sprite, animation, hframes_track)
+	animation.track_insert_key(hframes_track_index, 0, sprite.hframes)
+
+	var vframes_track = _get_property_track_path(player, sprite, "vframes")
+	var vframes_track_index = _create_track(sprite, animation, vframes_track)
+	animation.track_insert_key(vframes_track_index, 0, sprite.vframes)
+
+	var visible_track = _get_property_track_path(player, sprite, "visible")
+	var visible_track_index = _create_track(sprite, animation, visible_track)
+	animation.track_insert_key(visible_track_index, 0, true)
+
+	
+func _get_frame_key(sprite:  Node, frame: Dictionary, context: Dictionary):
+	return _calculate_frame_index(sprite,frame)
+
+
+func _calculate_frame_index(sprite: Node, frame: Dictionary) -> int:
+	var column = floor(frame.frame.x * sprite.hframes / sprite.texture.get_width())
+	var row = floor(frame.frame.y * sprite.vframes / sprite.texture.get_height())
+	return (row * sprite.hframes) + column
+

--- a/addons/AsepriteWizard/animation_player/texture_rect_animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/texture_rect_animation_creator.gd
@@ -1,0 +1,31 @@
+extends "animation_creator.gd"
+
+
+func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
+	context["base_texture"] = _load_texture(sprite_sheet)
+
+
+func _get_frame_property() -> String:
+		return "texture"
+
+
+func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary):
+	return _get_atlas_texture(context["base_texture"], frame)
+
+
+func _create_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
+	var texture_track = _get_property_track_path(player, target_node, "texture")
+	var texture_track_index = _create_track(target_node, animation, texture_track)
+	animation.track_insert_key(texture_track_index, 0, target_node.texture)
+
+	var visible_track = _get_property_track_path(player, target_node, "visible")
+	var visible_track_index = _create_track(target_node, animation, visible_track)
+	animation.track_insert_key(visible_track_index, 0, true)
+
+
+func _get_atlas_texture(base_texture: Texture, frame_data: Dictionary) -> AtlasTexture:
+	var tex = AtlasTexture.new()
+	tex.atlas = base_texture
+	tex.region = Rect2(Vector2(frame_data.frame.x, frame_data.frame.y), Vector2(frame_data.frame.w, frame_data.frame.h))
+	tex.filter_clip = true
+	return tex

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -20,6 +20,8 @@ const _PIXEL_2D_PRESET_CFG = 'res://addons/AsepriteWizard/config/2d_pixel_preset
 
 # cleanup
 const _REMOVE_SOURCE_FILES_KEY = 'aseprite/import/cleanup/remove_json_file'
+const _SET_VISIBLE_TRACK_AUTOMATICALLY = 'aseprite/import/cleanup/automatically_hide_sprites_not_in_animation'
+
 
 # automatic importer
 const _IMPORTER_ENABLE_KEY = 'aseprite/import/import_plugin/enable_automatic_importer'
@@ -104,6 +106,9 @@ func get_import_history() -> Array:
 			history.push_back(parse_json(line))
 
 	return history
+
+func is_set_visible_track_automatically_enabled() -> bool:
+	return _get_project_setting(_SET_VISIBLE_TRACK_AUTOMATICALLY, false)
 
 # history is saved and retrieved line-by-line so
 # file becomes version control friendly
@@ -219,6 +224,8 @@ func initialize_project_settings():
 	_initialize_project_cfg(_HISTORY_CONFIG_FILE_CFG_KEY, _DEFAULT_HISTORY_CONFIG_FILE_PATH, TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE)
 	_initialize_project_cfg(_HISTORY_SINGLE_ENTRY_KEY, false, TYPE_BOOL)
 
+	_initialize_project_cfg(_SET_VISIBLE_TRACK_AUTOMATICALLY, false, TYPE_BOOL)
+
 	ProjectSettings.save()
 
 	_initialize_editor_cfg(_COMMAND_KEY, default_command(), TYPE_STRING)
@@ -234,7 +241,8 @@ func clear_project_settings():
 		_REMOVE_SOURCE_FILES_KEY,
 		_IMPORTER_ENABLE_KEY,
 		_HISTORY_CONFIG_FILE_CFG_KEY,
-		_HISTORY_SINGLE_ENTRY_KEY
+		_HISTORY_SINGLE_ENTRY_KEY,
+		_SET_VISIBLE_TRACK_AUTOMATICALLY
 	]
 	for key in _all_settings:
 		ProjectSettings.clear(key)


### PR DESCRIPTION
This PR will enable the AnimationPlayer workflow for TextureRects. The code has been separated into multiple "animation_creator" files, where the "sprite_animation_creator" handles Sprite and Sprite3D nodes, and "texture_rect_animation_creator" handles TextureRects.

In addition https://github.com/viniciusgerevini/godot-aseprite-wizard/issues/67 is resolved by introducing a new ProjectSetting, _SET_VISIBLE_TRACK_AUTOMATICALLY, which defaults to disabled. 

This should make the plugin behavior more obvious, and it makes the advanced layering behavior opt-in. 

I did a small renaming of files to make it clear that it's not just sprites being handled anymore, but I'm not married to the nomenclature. 