### PR TITLE
refactored spriteframes and fixed automatic importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Breaking Changes
+
+Godot importer (Automatic resource importer) does not provide texture options animore (extra AtlasTextures, Spritesheets, etc). This was removed to reduce complexity and make the fix
+straight forward. I might re-introduce them as separated importers in the future upon request.
+
+### Changed
+
+- `sprite_frames_creator.gd` refactor
+- Removed extra automatic importer texture options
+
+### Fixed
+
+- Fixed automatic importer file size issue. You might still see some errors in the Output console, but files should be imported correctly with the right file size.
+
 ## 5.2.0 (2022-12-02)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -138,16 +138,9 @@ Notes:
 
 ### Importer
 
-__I intend to deprecate this feature in a next major release. It's too buggy and hacky compared to the other flows.__
-
 If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project will be automatically imported as a `SpriteFrames` resource, which can be used in `AnimatedSprite` nodes. You can change import settings for each file in the Import dock.
-This feature needs to be enabled via Aseprite Wizard Configuration screen.
 
-Notes:
-- The importer flow is kind o hacky and buggy. 
-- Files generated through the automatic importer can be significantly larger than those generated via other methods.
-- The importer does a bad job at refreshing Godot Editor cache. You might see resources outdated in the editor, but running the project will show the newest version.
-
+This feature needs to be enabled in the project settings. Requires editor restart.
 
 ### Options
 
@@ -157,16 +150,6 @@ Notes:
 | Exclude layers matching pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Split layers in multiple resources: | If selected, each layer will be exported as a separated resource (e.g my_layer_1.res, layer_name_2.res, ...). If not selected, all layers will be merged and exported as a single resource file with the same base name as the source. |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
-| Sprite filename pattern | Defines output filename. Default value: `{basename}.{layer}.{extension}` |
-| Import texture strip | Creates image strip (png) per sprite/layer. Default value: `false` |
-| Texture Strip Filename Pattern | Name for image strip file. Default value: `{basename}.{layer}.Strip.{extension}` |
-| Import Texture Atlas | Creates AtlasTexture per animation, along with textures for each animation frame. Default value: false |
-| Texture Atlas Filename Pattern | Name for AtlasTexture files. Default value: `{basename}.{layer}.Atlas.{extension}` |
-| Texture Atlas Frame Filename Pattern | Name for AtlasTexture frames files. Default value: `{basename}.{layer}.{animation}.{frame}.Atlas.{extension}` |
-| Import Animated Texture | Creates one AnimatedTexture for each animation. Default value: `false` |
-| Animated Texture Filename Pattern | Name for Animated Texture files. Default value: `{basename}.{layer}.{animation}.Texture.{extension}` |
-| Animated Texture Frame Filename Pattern | Name for Animated Texture frames files. Default value: `{basename}.{layer}.{animation}.{frame}.Texture.{extension}` |
-
 
 ## F.A.Q. and limitations
 
@@ -217,16 +200,6 @@ As you can select files from anywhere in your system, there is an export plugin 
 Godot is using the cached resource. Open another SpriteFrame and then re-open the affected one. You should see the newest version.
 
 This issue will only show outdated resources in the editor. When running the project you will always see the newest changes.
-
-
-### Files imported by the importer are bigger than the ones imported using the Wizard.
-
-The sprite sheet file (png) used in the resource is created by Aseprite, outside Godot Editor. Because of that, the plugin needs to trigger a file system scan to import this file.
-
-However, the scan operation is asynchronous and it can't be used in the importer. We implemented a fallback method but, unfortunately, it creates bigger resource files.
-
-Until we find an alternative way, the importer will create bigger files. To prevent it from generating resources for Aseprite files saved in your project folder, leave it disabled in the configuration screen or add a `.gdignore` file to the folder containing the `*.aseprite` files.
-
 
 ### Big files issue (Image width cannot be greater than 16384px)
 

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -73,7 +73,7 @@ func _set_layer(layer):
 	_layer_field.add_item(_layer)
 
 
-func _on_layer_pressed():
+func _on_layer_button_down():
 	if _source == "":
 		_show_message("Please. Select source file first.")
 		return
@@ -205,3 +205,4 @@ func _on_output_folder_selected(path):
 	_output_folder = path
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
 	_output_folder_dialog.queue_free()
+

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.tscn
@@ -219,8 +219,8 @@ margin_bottom = 116.0
 text = "Import"
 
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
+[connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
-[connection signal="pressed" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_pressed"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]
 [connection signal="pressed" from="margin/VBoxContainer/import" to="." method="_on_import_pressed"]

--- a/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
@@ -112,11 +112,12 @@ func _on_next_btn_up():
 		"only_visible_layers": _only_visible_layers_field().pressed,
 		"output_filename": _custom_name_field().text,
 		"do_not_create_resource": _do_not_create_res_field().pressed,
-		"remove_source_files_allowed": true
+		"remove_source_files_allowed": true,
+		"output_folder": output_location,
 	}
-	var exit_code = _sf_creator.create_resource(
+	var exit_code = _sf_creator.create_and_save_resources(
 		ProjectSettings.globalize_path(aseprite_file),
-		output_location, options
+		options
 	)
 	if exit_code is GDScriptFunctionState:
 		exit_code = yield(exit_code, "completed")

--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -3,15 +3,16 @@ extends EditorImportPlugin
 
 const result_codes = preload("../config/result_codes.gd")
 
-var _config = preload("../config/config.gd").new()
+var config
 var _sf_creator = preload("sprite_frames_creator.gd").new()
+var file_system: EditorFileSystem
 
 func get_importer_name():
-	return "aseprite.wizard.plugin"
+	return "aseprite_wizard.plugin"
 
 
 func get_visible_name():
-	return "Aseprite Importer"
+	return "Aseprite SpriteFrames Importer"
 
 
 func get_recognized_extensions():
@@ -40,21 +41,12 @@ func get_import_options(i):
 		{"name": "exclude_layers_pattern", "default_value": ''},
 		{"name": "only_visible_layers",    "default_value": false},
 		
-		{"name": "sheet_type", "default_value": "Packed", "property_hint": PROPERTY_HINT_ENUM, 
-			"hint_string": get_sheet_type_hint_string()},
-
-		{"name": "sprite_filename_pattern", "default_value": "{basename}.{layer}.{extension}"},
-
-		{"name": "texture_strip/import_texture_strip", "default_value": false},
-		{"name": "texture_strip/filename_pattern",     "default_value": "{basename}.{layer}.Strip.{extension}"},
-
-		{"name": "texture_atlas/import_texture_atlas",   "default_value": false},
-		{"name": "texture_atlas/filename_pattern",       "default_value": "{basename}.{layer}.Atlas.{extension}"},
-		{"name": "texture_atlas/frame_filename_pattern", "default_value": "{basename}.{layer}.{animation}.{frame}.Atlas.{extension}"},
-
-		{"name": "animated_texture/import_animated_texture", "default_value": false},
-		{"name": "animated_texture/filename_pattern",        "default_value": "{basename}.{layer}.{animation}.Texture.{extension}"},
-		{"name": "animated_texture/frame_filename_pattern",  "default_value": "{basename}.{layer}.{animation}.{frame}.Texture.{extension}"},
+		{
+			"name": "sheet_type",
+			"default_value": "Packed",
+			"property_hint": PROPERTY_HINT_ENUM,
+			"hint_string": get_sheet_type_hint_string()
+		},
 	]
 
 
@@ -62,12 +54,9 @@ func get_option_visibility(option, options):
 	return true
 
 
-static func replace_vars(pattern : String, vars : Dictionary):
-	var result = pattern;
-	for k in vars:
-		var v = vars[k]
-		result = result.replace("{%s}" % k, v)
-	return result
+func get_import_order():
+	return 1
+
 
 static func get_sheet_type_hint_string() -> String:
 	var hint_string := "Packed"
@@ -75,6 +64,7 @@ static func get_sheet_type_hint_string() -> String:
 		hint_string += ",%s columns" % number
 	hint_string += ",Strip"
 	return hint_string
+
 
 func import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
@@ -84,21 +74,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.find_last('.'))
 
-	_config.load_config()
-
-	_sf_creator.init(_config)
-
-	var dir = Directory.new()
-	dir.make_dir(save_path)
-
-	# Clear the directories contents
-	dir.open(save_path)
-	dir.list_dir_begin()
-	var file_name = dir.get_next()
-	while file_name != "":
-		if file_name != '.' and file_name != '..':
-			dir.remove(file_name)
-		file_name = dir.get_next()
+	_sf_creator.init(config, file_system)
 
 	var export_mode = _sf_creator.LAYERS_EXPORT_MODE if options['split_layers'] else _sf_creator.FILE_EXPORT_MODE
 
@@ -106,128 +82,40 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		"export_mode": export_mode,
 		"exception_pattern": options['exclude_layers_pattern'],
 		"only_visible_layers": options['only_visible_layers'],
-		"output_filename": '',
+		"output_filename": '' if export_mode == _sf_creator.FILE_EXPORT_MODE else '%s_' % source_basename,
 		"column_count" : int(options['sheet_type']) if options['sheet_type'] != "Strip" else 128,
+		"output_folder": source_path,
 	}
+	
+	var resources = _sf_creator.create_resources(absolute_source_file, aseprite_opts)
 
-	var exit_code = _sf_creator.create_resource(absolute_source_file, absolute_save_path, aseprite_opts)
-	if exit_code != OK:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(exit_code))
+	if resources is GDScriptFunctionState:
+		resources = yield(resources, "completed")
+
+	if not resources.is_ok:
+		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
 		return FAILED
 
-	dir.open(save_path)
-	dir.list_dir_begin()
+	if export_mode == _sf_creator.LAYERS_EXPORT_MODE:
+		# each layer is saved as one resource using base file name to prevent
+		# collisions
+		# the first layer will be saved in the default resource path to prevent
+		# godot from keeping re-importing it
+		for resource in resources.content:
+			var resource_path = "%s.res" % resource.data_file.get_basename();
+			var exit_code = ResourceSaver.save(resource_path, resource.resource)
+			resource.resource.take_over_path(resource_path)
 
-	file_name = dir.get_next()
+			if exit_code != OK:
+				printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+				return FAILED
 
-	var main_sprite_frame_saved = false
+	var resource = resources.content[0]
+	var resource_path = "%s.res" % save_path
+	var exit_code = ResourceSaver.save(resource_path, resource.resource)
+	resource.resource.take_over_path(resource_path)
 
-	var global_replacement_vars = {
-		"basename": source_basename,
-	}
-
-	# Scan through the import directory and process the generated resources based on what options have been selected.
-	while file_name != "":
-		if file_name != ".." and file_name != ".":
-			if file_name.ends_with(".res"):
-				# This is a SpriteFrames resource generated for a layer.
-				var local_replacement_vars = global_replacement_vars.duplicate()
-				local_replacement_vars["layer"] = file_name.substr(0, file_name.length() - 4)
-
-				if not main_sprite_frame_saved:
-					# Save this resource as the main resource. We need to set something here or Godot won't stop
-					# re-importing the resource. So this is either the SpriteFrames instance of the first layer
-					# (alphabetically) found in the import directory.
-					var sprite_frames : SpriteFrames = ResourceLoader.load("%s/%s" % [save_path, file_name], 'SpriteFrames', true)
-					main_sprite_frame_saved = true
-					var resource_path = "%s.res" % save_path;
-					sprite_frames.take_over_path(resource_path)
-					ResourceSaver.save(resource_path, sprite_frames)
-
-				var sprite_frames : SpriteFrames = ResourceLoader.load("%s/%s" % [save_path, file_name], 'SpriteFrames', true)
-
-				if options["split_layers"]:
-					var sprite_replacement_vars = local_replacement_vars.duplicate()
-					sprite_replacement_vars["extension"] = "res"
-
-					var sprite_filename = "%s/%s" % [source_path, replace_vars(options["sprite_filename_pattern"], sprite_replacement_vars)]
-					ResourceSaver.save(sprite_filename, sprite_frames)
-					sprite_frames.take_over_path(sprite_filename)
-
-				if options["texture_atlas/import_texture_atlas"]:
-					# Create a TextureAtlas resource for this layer.
-					var atlas_texture = null
-					var replacement_vars = local_replacement_vars.duplicate()
-
-					for anim in sprite_frames.animations:
-						var i=0
-
-						replacement_vars["animation"] = anim.name
-						replacement_vars["extension"] = "res"
-
-						for frame in anim.frames:
-							replacement_vars["frame"] = i
-
-							if not atlas_texture:
-								atlas_texture = (frame as AtlasTexture).atlas
-
-								var atlas_filename = "%s/%s" % [source_path, replace_vars(options["texture_atlas/filename_pattern"], replacement_vars)]
-								ResourceSaver.save(atlas_filename, atlas_texture)
-								atlas_texture.take_over_path(atlas_filename)
-
-							frame.atlas = atlas_texture
-
-							var frame_filename = "%s/%s" % [source_path, replace_vars(options["texture_atlas/frame_filename_pattern"], replacement_vars)]
-							ResourceSaver.save(frame_filename, frame)
-							i+=1
-
-				if options["animated_texture/import_animated_texture"]:
-					var replacement_vars = local_replacement_vars.duplicate()
-					replacement_vars["extension"] = "res"
-
-					for anim in sprite_frames.animations:
-						replacement_vars["animation"] = anim.name
-
-						var tex : AnimatedTexture = AnimatedTexture.new()
-						tex.frames = anim.frames.size()
-
-						var i=0
-						for frame in anim.frames:
-							replacement_vars["frame"] = i
-
-							var atlas_tex = frame as AtlasTexture
-							var image : Image = atlas_tex.atlas.get_data()
-							var single_image = Image.new()
-							single_image.create(atlas_tex.get_width(), atlas_tex.get_height(), false, image.get_format())
-							single_image.blit_rect(image, atlas_tex.region, Vector2.ZERO)
-
-							var frame_filename = "%s/%s" % [source_path, replace_vars(options["animated_texture/frame_filename_pattern"], replacement_vars)]
-
-							var res = ImageTexture.new()
-							res.create_from_image(single_image, 0)
-							res.flags = atlas_tex.flags
-							ResourceSaver.save(frame_filename, res)
-							res.take_over_path(frame_filename)
-
-							tex.set_frame_texture(i, res)
-
-							i+=1
-
-						var texture_filename = "%s/%s" % [source_path, replace_vars(options["animated_texture/filename_pattern"], replacement_vars)]
-						ResourceSaver.save(texture_filename, tex)
-
-			elif options['texture_strip/import_texture_strip'] and file_name.ends_with(".png"):
-				var replacement_vars = global_replacement_vars.duplicate()
-				replacement_vars["layer"] = file_name.substr(0, file_name.length() - 4)
-				replacement_vars["extension"] = "png"
-
-				var texture_filename = "%s/%s" % [source_path, replace_vars(options["texture_strip/filename_pattern"], replacement_vars)]
-
-				var img : Image = Image.new()
-				img.load("%s/%s" % [save_path, file_name])
-				var res = ImageTexture.new()
-				res.create_from_image(img, 0)
-				ResourceSaver.save(texture_filename, res)
-
-		file_name = dir.get_next()
+	if exit_code != OK:
+		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		return FAILED
 	return OK

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -11,34 +11,36 @@ enum {
 
 var _config
 var _file_system: EditorFileSystem
-var _should_check_file_system := false
+#var _should_check_file_system := false
 
 
 func init(config, editor_file_system: EditorFileSystem = null):
 	_config = config
 	_file_system = editor_file_system
-	_should_check_file_system = _file_system != null
+#	_should_check_file_system = _file_system != null
 	_aseprite.init(config)
 
 
-func _loop_config_prefix() -> String:
-	return _config.get_animation_loop_exception_prefix()
-
-
-func _is_loop_config_enabled() -> String:
-	return _config.is_default_animation_loop_enabled()
-
-
-func create_animations(sprite: Node, options: Dictionary):
+func _initial_checks(source: String, options: Dictionary) -> int:
 	if not _aseprite.test_command():
 		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
 
 	var dir = Directory.new()
-	if not dir.file_exists(options.source):
+	if not dir.file_exists(source):
 		return result_code.ERR_SOURCE_FILE_NOT_FOUND
 
 	if not dir.dir_exists(options.output_folder):
 		return result_code.ERR_OUTPUT_FOLDER_NOT_FOUND
+	
+	return result_code.SUCCESS
+
+
+func create_animations(sprite: Node, options: Dictionary) -> void:
+	var input_check = _initial_checks(options.source, options)
+	
+	if input_check != result_code.SUCCESS:
+		printerr(result_code.get_error_message(input_check))
+		return
 
 	var result = _create_animations_from_file(sprite, options)
 
@@ -49,7 +51,32 @@ func create_animations(sprite: Node, options: Dictionary):
 		printerr(result_code.get_error_message(result))
 
 
-func _create_animations_from_file(sprite: Node, options: Dictionary):
+func _create_animations_from_file(animated_sprite: Node, options: Dictionary) -> int:
+	var output = _export_aseprite_file(options)
+	
+	if not output.is_ok:
+		return output.code
+
+	if _config.is_import_preset_enabled():
+		_config.create_import_file(output.content)
+
+	yield(_scan_filesystem(), "completed")
+
+	var sprite_frames_result = _create_sprite_frames(output.content)
+	if not sprite_frames_result.is_ok:
+		return sprite_frames_result.code
+
+	animated_sprite.frames = sprite_frames_result.content
+
+
+	if _config.should_remove_source_files():
+		var dir = Directory.new()
+		dir.remove(output.content.data_file)
+
+	return result_code.SUCCESS
+
+
+func _export_aseprite_file(options: Dictionary) -> Dictionary:
 	var output
 
 	if options.get("layer", "") == "":
@@ -58,130 +85,252 @@ func _create_animations_from_file(sprite: Node, options: Dictionary):
 		output = _aseprite.export_layer(options.source, options.layer, options.output_folder, options)
 
 	if output.empty():
-		return result_code.ERR_ASEPRITE_EXPORT_FAILED
+		return result_code.error(result_code.ERR_ASEPRITE_EXPORT_FAILED)
 
-	if _config.is_import_preset_enabled():
-		_config.create_import_file(output)
+	return result_code.result(output)
+
+
+func create_and_save_resources(source_file: String, options: Dictionary) -> int:
+	var resources = yield(create_resources(source_file, options), "completed")
+
+	if resources.is_ok:
+		return _save_resources(resources.content)
+
+	return resources.code
+
+
+func create_resources(source_file: String, options = {}) -> Dictionary:
+	var input_check = _initial_checks(source_file, options)
+
+	if input_check != result_code.SUCCESS:
+		return result_code.error(input_check)
+
+	var output = _create_aseprite_output_files(source_file, options)
+	if not output.is_ok:
+		return output
 
 	yield(_scan_filesystem(), "completed")
 
-	var result = _import(output, sprite)
+	var result = _create_sprite_frames_from_source(output.content, options)
 
-	if _config.should_remove_source_files():
-		var dir = Directory.new()
-		dir.remove(output.data_file)
-		yield(_scan_filesystem(), "completed")
+	if not result.is_ok:
+		return result
+
+	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()	
+
+	if should_remove_source:
+		_remove_source_files(result.content)
 
 	return result
 
 
-func create_resource(source_file: String, output_folder: String, options = {}):
-	var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
-
-	if not _aseprite.test_command():
-		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
-
+func _remove_source_files(source_files: Array):
 	var dir = Directory.new()
-	if not dir.file_exists(source_file):
-		return result_code.ERR_SOURCE_FILE_NOT_FOUND
+	for s in source_files:
+		dir.remove(s.data_file)
 
-	if not dir.dir_exists(output_folder):
-		return result_code.ERR_OUTPUT_FOLDER_NOT_FOUND
+	yield(_scan_filesystem(), "completed")
 
-	match export_mode:
+
+func _create_aseprite_output_files(source_file: String, options: Dictionary):
+	match options.get('export_mode', FILE_EXPORT_MODE):
 		FILE_EXPORT_MODE:
-			if _should_check_file_system:
-				return yield(create_sprite_frames_from_aseprite_file(source_file, output_folder, options), "completed")
-			return create_sprite_frames_from_aseprite_file(source_file, output_folder, options)
+			return result_code.result(
+				[_aseprite.export_file(source_file, options.output_folder, options)]
+			)
 		LAYERS_EXPORT_MODE:
-			if _should_check_file_system:
-				return yield(create_sprite_frames_from_aseprite_layers(source_file, output_folder, options), "completed")
-			return create_sprite_frames_from_aseprite_layers(source_file, output_folder, options)
+			var output = _aseprite.export_layers(source_file, options.output_folder, options)
+			if output.empty():
+				return result_code.error(result_code.ERR_NO_VALID_LAYERS_FOUND)
+			return result_code.result(output)
 		_:
-			return result_code.ERR_UNKNOWN_EXPORT_MODE
+			return result_code.error(result_code.ERR_UNKNOWN_EXPORT_MODE)
 
 
-func create_sprite_frames_from_aseprite_file(source_file: String, output_folder: String, options: Dictionary):
-	var output = _aseprite.export_file(source_file, output_folder, options)
-	if output.empty():
-		return result_code.ERR_ASEPRITE_EXPORT_FAILED
-
-	if (_should_check_file_system):
-		yield(_scan_filesystem(), "completed")
-
-	if options.get("do_not_create_resource", false):
-		return OK
-
-	var result = _import(output)
-
-	if options.get("remove_source_files_allowed", false) and _config.should_remove_source_files():
-		var dir = Directory.new()
-		dir.remove(output.data_file)
-		if (_should_check_file_system):
-			yield(_scan_filesystem(), "completed")
-
-	return result
-
-
-func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary):
-	var output = _aseprite.export_layers(source_file, output_folder, options)
-	if output.empty():
-		return result_code.ERR_NO_VALID_LAYERS_FOUND
-
-	var result = OK
-
-	if (_should_check_file_system):
-		yield(_scan_filesystem(), "completed")
-
+func _create_sprite_frames_from_source(source_files: Array, options: Dictionary) -> Dictionary:
 	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()
 
-	for o in output:
+	var resources = []
+
+	for o in source_files:
 		if o.empty():
-			result = result_code.ERR_ASEPRITE_EXPORT_FAILED
-		else:
-			if options.get("do_not_create_resource", false):
-				result = OK
-			else:
-				result = _import(o)
-				if should_remove_source:
-					var dir = Directory.new()
-					dir.remove(o.data_file)
+			return result_code.error(result_code.ERR_ASEPRITE_EXPORT_FAILED)
 
-	if should_remove_source and _should_check_file_system:
-		yield(_scan_filesystem(), "completed")
+		var resource = _create_sprite_frames(o)
 
-	return result
+		if not resource.is_ok:
+			return resource
 
+		resources.push_back({
+			"data_file": o.data_file,
+			"resource": resource.content,
+		})
 
-func _get_file_basename(file_path: String) -> String:
-	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
+	return result_code.result(resources)
 
 
-func _import(data, animated_sprite = null) -> int:
-	var source_file = data.data_file
-	var sprite_sheet = data.sprite_sheet
+func _create_sprite_frames(data) -> Dictionary:
+	var aseprite_resources = _load_aseprite_resources(data)
+	if not aseprite_resources.is_ok:
+		return aseprite_resources
+
+	return result_code.result(
+		_create_sprite_frames_with_animations(
+			aseprite_resources.content.metadata,
+			aseprite_resources.content.texture
+		)
+	)
+
+
+func _load_aseprite_resources(aseprite_data: Dictionary):
+	var content_result = _load_json_content(aseprite_data.data_file)
+
+	if not content_result.is_ok:
+		return content_result
+
+	var texture = _parse_texture_path(aseprite_data.sprite_sheet)
+
+	return result_code.result({
+		"metadata": content_result.content,
+		"texture": texture
+	})
+
+
+func _load_json_content(source_file: String) -> Dictionary:
 	var file = File.new()
 	var err = file.open(source_file, File.READ)
 	if err != OK:
-			return err
+		return result_code.error(err)
+
 	var content =  parse_json(file.get_as_text())
 
 	if not _aseprite.is_valid_spritesheet(content):
-		return result_code.ERR_INVALID_ASEPRITE_SPRITESHEET
+		return result_code.error(result_code.ERR_INVALID_ASEPRITE_SPRITESHEET)
 
-	var texture = _parse_texture_path(sprite_sheet)
-	texture.take_over_path(sprite_sheet)
+	return result_code.result(content)
 
-	var resource = _create_sprite_frames_with_animations(content, texture)
 
-	if is_instance_valid(animated_sprite):
-		animated_sprite.frames = resource
-		return result_code.SUCCESS
+func _save_resources(resources: Array) -> int:
+	for resource in resources:
+		var code = _save_resource(resource.resource, resource.data_file)
+		if code != OK:
+			return code
+	return OK
 
-	var save_path = "%s.%s" % [source_file.get_basename(), "res"]
-	var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
+
+func _save_resource(resource, source_path: String) -> int:
+	var save_path = "%s.%s" % [source_path.get_basename(), "res"]
+	var code = ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
 	resource.take_over_path(save_path)
 	return code
+
+
+#func create_resource(source_file: String, output_folder: String, options = {}):
+#	var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
+#
+#	if not _aseprite.test_command():
+#		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
+#
+#	var dir = Directory.new()
+#	if not dir.file_exists(source_file):
+#		return result_code.ERR_SOURCE_FILE_NOT_FOUND
+#
+#	if not dir.dir_exists(output_folder):
+#		return result_code.ERR_OUTPUT_FOLDER_NOT_FOUND
+#
+#	match export_mode:
+#		FILE_EXPORT_MODE:
+#			if _should_check_file_system:
+#				return yield(create_sprite_frames_from_aseprite_file(source_file, output_folder, options), "completed")
+#			return create_sprite_frames_from_aseprite_file(source_file, output_folder, options)
+#		LAYERS_EXPORT_MODE:
+#			if _should_check_file_system:
+#				return yield(create_sprite_frames_from_aseprite_layers(source_file, output_folder, options), "completed")
+#			return create_sprite_frames_from_aseprite_layers(source_file, output_folder, options)
+#		_:
+#			return result_code.ERR_UNKNOWN_EXPORT_MODE
+#
+#
+#func create_sprite_frames_from_aseprite_file(source_file: String, output_folder: String, options: Dictionary):
+#	var output = _aseprite.export_file(source_file, output_folder, options)
+#	if output.empty():
+#		return result_code.ERR_ASEPRITE_EXPORT_FAILED
+#
+#	if (_should_check_file_system):
+#		yield(_scan_filesystem(), "completed")
+#
+#	if options.get("do_not_create_resource", false):
+#		return OK
+#
+#	var result = _import(output)
+#
+#	if options.get("remove_source_files_allowed", false) and _config.should_remove_source_files():
+#		var dir = Directory.new()
+#		dir.remove(output.data_file)
+#		if (_should_check_file_system):
+#			yield(_scan_filesystem(), "completed")
+#
+#	return result
+#
+#
+#func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary):
+#	var output = _aseprite.export_layers(source_file, output_folder, options)
+#	if output.empty():
+#		return result_code.ERR_NO_VALID_LAYERS_FOUND
+#
+#	var result = OK
+#
+#	if (_should_check_file_system):
+#		yield(_scan_filesystem(), "completed")
+#
+#	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()
+#
+#	for o in output:
+#		if o.empty():
+#			result = result_code.ERR_ASEPRITE_EXPORT_FAILED
+#		else:
+#			if options.get("do_not_create_resource", false):
+#				result = OK
+#			else:
+#				result = _import(o)
+#				if should_remove_source:
+#					var dir = Directory.new()
+#					dir.remove(o.data_file)
+#
+#	if should_remove_source and _should_check_file_system:
+#		yield(_scan_filesystem(), "completed")
+#
+#	return result
+
+
+
+
+
+#func _import(data, animated_sprite = null) -> int:
+#	var source_file = data.data_file
+#	var sprite_sheet = data.sprite_sheet
+#	var file = File.new()
+#	var err = file.open(source_file, File.READ)
+#	if err != OK:
+#			return err
+#	var content =  parse_json(file.get_as_text())
+#
+#	if not _aseprite.is_valid_spritesheet(content):
+#		return result_code.ERR_INVALID_ASEPRITE_SPRITESHEET
+#
+#	var texture = _parse_texture_path(sprite_sheet)
+#	texture.take_over_path(sprite_sheet)
+#
+#	var resource = _create_sprite_frames_with_animations(content, texture)
+#
+#	if is_instance_valid(animated_sprite):
+#		animated_sprite.frames = resource
+#		return result_code.SUCCESS
+#
+#	var save_path = "%s.%s" % [source_file.get_basename(), "res"]
+#	var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
+#	resource.take_over_path(save_path)
+#	return code
 
 
 func _create_sprite_frames_with_animations(content, texture) -> SpriteFrames:
@@ -254,16 +403,6 @@ func _get_min_duration(frames) -> int:
 
 
 func _parse_texture_path(path):
-	if not _should_check_file_system and not ResourceLoader.has_cached(path):
-		# this is a fallback for the importer. It generates the spritesheet file when it hasn't
-		# been imported before. Files generated in this method are usually
-		# bigger in size than the ones imported by Godot's default importer.
-		var image = Image.new()
-		image.load(path)
-		var texture = ImageTexture.new()
-		texture.create_from_image(image, 0)
-		return texture
-
 	return ResourceLoader.load(path, 'Image', true)
 
 
@@ -313,3 +452,15 @@ func _scan_filesystem():
 
 func list_layers(file: String, only_visibles = false) -> Array:
 	return _aseprite.list_layers(file, only_visibles)
+
+
+func _get_file_basename(file_path: String) -> String:
+	return file_path.get_file().trim_suffix('.%s' % file_path.get_extension())
+
+
+func _loop_config_prefix() -> String:
+	return _config.get_animation_loop_exception_prefix()
+
+
+func _is_loop_config_enabled() -> String:
+	return _config.is_default_animation_loop_enabled()

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -167,17 +167,37 @@ func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Di
 	if not (content.meta.has("frameTags") and content.meta.frameTags.size() > 0):
 		return result_code.SUCCESS
 
-	var tags = ["RESET"]
-	for t in content.meta.frameTags:
-		var a = t.name
-		if a.begins_with(_config.get_animation_loop_exception_prefix()):
-			a = a.substr(_config.get_animation_loop_exception_prefix().length())
-		tags.push_back(a)
+	_remove_unused_animations(content, player)
 
 	if options.get("cleanup_hide_unused_nodes", false):
-		_hide_unused_nodes(target_node, player, content)	
+		_hide_unused_nodes(target_node, player, content)
 
 	return result_code.SUCCESS
+
+
+func _remove_unused_animations(content: Dictionary, player: AnimationPlayer):
+	pass # FIXME it's not removing unused animations anymore. Sample impl bellow
+#	var tags = ["RESET"]
+#	for t in content.meta.frameTags:
+#		var a = t.name
+#		if a.begins_with(_config.get_animation_loop_exception_prefix()):
+#			a = a.substr(_config.get_animation_loop_exception_prefix().length())
+#		tags.push_back(a)
+
+#   var track = _get_frame_track_path(player, sprite)
+#	for a in player.get_animation_list():
+#		if tags.has(a):
+#			continue
+#
+#		var animation = player.get_animation(a)
+#		if animation.get_track_count() != 1:
+#			var t = animation.find_track(track)
+#			if t != -1:
+#				animation.remove_track(t)
+#			continue
+#
+#		if animation.find_track(track) != -1:
+#			player.remove_animation(a)
 
 
 func _hide_unused_nodes(target_node: Node, player: AnimationPlayer, content: Dictionary):

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
@@ -96,7 +96,7 @@ func _set_layer(layer):
 	_layer_field.add_item(_layer)
 
 
-func _on_options_pressed():
+func _on_options_button_down():
 	var animation_players = []
 	var root = get_tree().get_edited_scene_root()
 	_find_animation_players(root, root, animation_players)
@@ -129,7 +129,8 @@ func _on_options_item_selected(index):
 	_save_config()
 
 
-func _on_layer_pressed():
+
+func _on_layer_button_down():
 	if _source == "":
 		_show_message("Please. Select source file first.")
 		return
@@ -273,3 +274,4 @@ func _on_output_folder_selected(path):
 	_output_folder = path
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
 	_output_folder_dialog.queue_free()
+

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
@@ -262,11 +262,11 @@ margin_right = 187.0
 margin_bottom = 140.0
 text = "Import"
 
+[connection signal="button_down" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_item_selected"]
-[connection signal="pressed" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_pressed"]
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
+[connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
-[connection signal="pressed" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_pressed"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]
 [connection signal="pressed" from="margin/VBoxContainer/import" to="." method="_on_import_pressed"]

--- a/addons/AsepriteWizard/config/result_codes.gd
+++ b/addons/AsepriteWizard/config/result_codes.gd
@@ -27,3 +27,11 @@ static func get_error_message(code: int):
 			return "no valid layers found"
 		_:
 			return "import failed with code %d" % code
+
+
+static func error(error_code: int):
+	return { "code": error_code, "content": null, "is_ok": false }
+
+
+static func result(result):
+	return { "code": SUCCESS, "content": result, "is_ok": true }

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -65,6 +65,8 @@ func _remove_menu_entries():
 func _setup_importer():
 	if config.is_importer_enabled():
 		import_plugin = ImportPlugin.new()
+		import_plugin.file_system = get_editor_interface().get_resource_filesystem()
+		import_plugin.config = config
 		add_import_plugin(import_plugin)
 		_importer_enabled = true
 

--- a/icon.png.import
+++ b/icon.png.import
@@ -28,6 +28,7 @@ process/fix_alpha_border=true
 process/premult_alpha=false
 process/HDR_as_SRGB=false
 process/invert_color=false
+process/normal_map_invert_y=false
 stream=false
 size_limit=0
 detect_3d=true


### PR DESCRIPTION
- `sprite_frames_creator.gd` refactor
- Fixed importer. Now file sizes are consistent with other methods. No hacky import. Warnings might still appear in the output console.

With this PR I believe it's safe to close #40, as there is no hacky texture importing happening anymore.