### PR TITLE
Fix default directory in file dialogue not being saved

### DIFF
--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
@@ -216,7 +216,7 @@ func _open_source_dialog():
 	_file_dialog_aseprite = _create_aseprite_file_selection()
 	get_parent().add_child(_file_dialog_aseprite)
 	if _source != "":
-		_file_dialog_aseprite.current_dir = _source.get_base_dir()
+		_file_dialog_aseprite.current_dir = ProjectSettings.globalize_path(_source.get_base_dir())
 	_file_dialog_aseprite.popup_centered_ratio()
 
 


### PR DESCRIPTION
When selecting an Aseprite to import, the file dialogue should default to the current directory of the selected file. This currently doesn't work because the path being set is local to the project. This just fixes it by converting the path to a global path.