### PR TITLE
Use ProjectSettings to make local and abs paths

### DIFF
--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -17,7 +17,7 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 	var only_visible_layers = options.get('only_visible_layers', false)
 	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename', file_name)
 	var basename = _get_file_basename(output_name)
-	var output_dir = output_folder.replace("res://", "./")
+	var output_dir = ProjectSettings.globalize_path(output_folder)
 	var data_file = "%s/%s.json" % [output_dir, basename]
 	var sprite_sheet = "%s/%s.png" % [output_dir, basename]
 	var output = []
@@ -37,15 +37,14 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 		return {}
 
 	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
+		'data_file': ProjectSettings.localize_path(data_file),
+		"sprite_sheet": ProjectSettings.localize_path(sprite_sheet)
 	}
 
 
 func export_layers(file_name: String, output_folder: String, options: Dictionary) -> Array:
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
-	var basename = _get_file_basename(file_name)
 	var layers = list_layers(file_name, only_visible_layers)
 	var exception_regex = _compile_regex(exception_pattern)
 
@@ -60,14 +59,14 @@ func export_layers(file_name: String, output_folder: String, options: Dictionary
 
 func export_layer(file_name: String, layer_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var output_prefix = options.get('output_filename', "").strip_edges()
-	var output_dir = output_folder.replace("res://", "./").strip_edges()
+	var output_dir = ProjectSettings.globalize_path(output_folder)
 	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, layer_name]
 	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, layer_name]
 	var output = []
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 	arguments.push_front(layer_name)
 	arguments.push_front("--layer")
-	
+
 	_add_sheet_type_arguments(arguments, options)
 
 	var exit_code = _execute(arguments, output)
@@ -77,8 +76,8 @@ func export_layer(file_name: String, layer_name: String, output_folder: String, 
 		return {}
 
 	return {
-		'data_file': data_file.replace("./", "res://"),
-		"sprite_sheet": sprite_sheet.replace("./", "res://")
+		'data_file': ProjectSettings.localize_path(data_file),
+		"sprite_sheet": ProjectSettings.localize_path(sprite_sheet)
 	}
 
 
@@ -129,7 +128,7 @@ func list_layers(file_name: String, only_visible = false) -> Array:
 
 	if output.empty():
 		return output
-	
+
 	var raw = output[0].split('\n')
 	var sanitized = []
 	for s in raw:


### PR DESCRIPTION
Use the standardized functions `ProjectSettings.globalize_path` and `ProjectSettings.localize_path` to get absolute and local paths respectively. This has the side effect of using an absolute file path when passing arguments to aseprite which seems to work around an issue in v1.3-beta21 with not handling relative paths on the CLI.