### PR TITLE
Use correct enum for texture filter on 2D and 3D nodes

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -63,7 +63,11 @@ func _create_animations_from_file(animated_sprite: Node, options: Dictionary) ->
 		return sprite_frames_result.code
 
 	animated_sprite.frames = sprite_frames_result.content
-	animated_sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+
+	if animated_sprite is CanvasItem:
+		animated_sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	else:
+		animated_sprite.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
 
 	if _config.should_remove_source_files():
 		DirAccess.remove_absolute(output.content.data_file)

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -72,7 +72,11 @@ func _import(target_node: Node, player: AnimationPlayer, data: Dictionary, optio
 	
 	var context = {}
 
-	target_node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	if target_node is CanvasItem:
+		target_node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	else:
+		target_node.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+
 	_setup_texture(target_node, sprite_sheet, content, context)
 	var result = _configure_animations(target_node, player, content, context)
 	if result != result_code.SUCCESS:


### PR DESCRIPTION
Adding the fix implemented by @IPDramon on #80.

I just included the changes and tested them so I took the liberty to include them as commit author.