### PR TITLE
Auto-importer: use default exclusion pattern from settings and fix json file cleanup

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
@@ -112,7 +112,6 @@ func _on_next_btn_up():
 		"only_visible_layers": _only_visible_layers_field().pressed,
 		"output_filename": _custom_name_field().text,
 		"do_not_create_resource": _do_not_create_res_field().pressed,
-		"remove_source_files_allowed": true,
 		"output_folder": output_location,
 	}
 	var exit_code = _sf_creator.create_and_save_resources(

--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -38,7 +38,7 @@ func get_preset_name(i):
 func get_import_options(i):
 	return [
 		{"name": "split_layers",           "default_value": false},
-		{"name": "exclude_layers_pattern", "default_value": ''},
+		{"name": "exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
 		{"name": "only_visible_layers",    "default_value": false},
 		
 		{

--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -86,7 +86,7 @@ func import(source_file, save_path, options, platform_variants, gen_files):
 		"column_count" : int(options['sheet_type']) if options['sheet_type'] != "Strip" else 128,
 		"output_folder": source_path,
 	}
-	
+
 	var resources = _sf_creator.create_resources(absolute_source_file, aseprite_opts)
 
 	if resources is GDScriptFunctionState:

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -116,7 +116,7 @@ func create_resources(source_file: String, options = {}) -> Dictionary:
 	if not result.is_ok:
 		return result
 
-	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()	
+	var should_remove_source = _config.should_remove_source_files()	
 
 	if should_remove_source:
 		_remove_source_files(result.content)
@@ -148,7 +148,7 @@ func _create_aseprite_output_files(source_file: String, options: Dictionary):
 
 
 func _create_sprite_frames_from_source(source_files: Array, options: Dictionary) -> Dictionary:
-	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()
+	var should_remove_source = _config.should_remove_source_files()
 
 	var resources = []
 

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -11,13 +11,11 @@ enum {
 
 var _config
 var _file_system: EditorFileSystem
-#var _should_check_file_system := false
 
 
 func init(config, editor_file_system: EditorFileSystem = null):
 	_config = config
 	_file_system = editor_file_system
-#	_should_check_file_system = _file_system != null
 	_aseprite.init(config)
 
 
@@ -223,114 +221,6 @@ func _save_resource(resource, source_path: String) -> int:
 	var code = ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
 	resource.take_over_path(save_path)
 	return code
-
-
-#func create_resource(source_file: String, output_folder: String, options = {}):
-#	var export_mode = options.get('export_mode', FILE_EXPORT_MODE)
-#
-#	if not _aseprite.test_command():
-#		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
-#
-#	var dir = Directory.new()
-#	if not dir.file_exists(source_file):
-#		return result_code.ERR_SOURCE_FILE_NOT_FOUND
-#
-#	if not dir.dir_exists(output_folder):
-#		return result_code.ERR_OUTPUT_FOLDER_NOT_FOUND
-#
-#	match export_mode:
-#		FILE_EXPORT_MODE:
-#			if _should_check_file_system:
-#				return yield(create_sprite_frames_from_aseprite_file(source_file, output_folder, options), "completed")
-#			return create_sprite_frames_from_aseprite_file(source_file, output_folder, options)
-#		LAYERS_EXPORT_MODE:
-#			if _should_check_file_system:
-#				return yield(create_sprite_frames_from_aseprite_layers(source_file, output_folder, options), "completed")
-#			return create_sprite_frames_from_aseprite_layers(source_file, output_folder, options)
-#		_:
-#			return result_code.ERR_UNKNOWN_EXPORT_MODE
-#
-#
-#func create_sprite_frames_from_aseprite_file(source_file: String, output_folder: String, options: Dictionary):
-#	var output = _aseprite.export_file(source_file, output_folder, options)
-#	if output.empty():
-#		return result_code.ERR_ASEPRITE_EXPORT_FAILED
-#
-#	if (_should_check_file_system):
-#		yield(_scan_filesystem(), "completed")
-#
-#	if options.get("do_not_create_resource", false):
-#		return OK
-#
-#	var result = _import(output)
-#
-#	if options.get("remove_source_files_allowed", false) and _config.should_remove_source_files():
-#		var dir = Directory.new()
-#		dir.remove(output.data_file)
-#		if (_should_check_file_system):
-#			yield(_scan_filesystem(), "completed")
-#
-#	return result
-#
-#
-#func create_sprite_frames_from_aseprite_layers(source_file: String, output_folder: String, options: Dictionary):
-#	var output = _aseprite.export_layers(source_file, output_folder, options)
-#	if output.empty():
-#		return result_code.ERR_NO_VALID_LAYERS_FOUND
-#
-#	var result = OK
-#
-#	if (_should_check_file_system):
-#		yield(_scan_filesystem(), "completed")
-#
-#	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()
-#
-#	for o in output:
-#		if o.empty():
-#			result = result_code.ERR_ASEPRITE_EXPORT_FAILED
-#		else:
-#			if options.get("do_not_create_resource", false):
-#				result = OK
-#			else:
-#				result = _import(o)
-#				if should_remove_source:
-#					var dir = Directory.new()
-#					dir.remove(o.data_file)
-#
-#	if should_remove_source and _should_check_file_system:
-#		yield(_scan_filesystem(), "completed")
-#
-#	return result
-
-
-
-
-
-#func _import(data, animated_sprite = null) -> int:
-#	var source_file = data.data_file
-#	var sprite_sheet = data.sprite_sheet
-#	var file = File.new()
-#	var err = file.open(source_file, File.READ)
-#	if err != OK:
-#			return err
-#	var content =  parse_json(file.get_as_text())
-#
-#	if not _aseprite.is_valid_spritesheet(content):
-#		return result_code.ERR_INVALID_ASEPRITE_SPRITESHEET
-#
-#	var texture = _parse_texture_path(sprite_sheet)
-#	texture.take_over_path(sprite_sheet)
-#
-#	var resource = _create_sprite_frames_with_animations(content, texture)
-#
-#	if is_instance_valid(animated_sprite):
-#		animated_sprite.frames = resource
-#		return result_code.SUCCESS
-#
-#	var save_path = "%s.%s" % [source_file.get_basename(), "res"]
-#	var code =  ResourceSaver.save(save_path, resource, ResourceSaver.FLAG_REPLACE_SUBRESOURCE_PATHS)
-#	resource.take_over_path(save_path)
-#	return code
 
 
 func _create_sprite_frames_with_animations(content, texture) -> SpriteFrames:


### PR DESCRIPTION
- Use default exclusion pattern from project settings in the importer
- Remove legacy setting stopping JSON files from being removed
- Clean up some old commented code

#81 