### PR TITLE
Godot 4: Auto-importer: use default exclusion pattern from settings and fix json file cleanup

### DIFF
--- a/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/as_wizard_window.gd
@@ -113,7 +113,6 @@ func _on_next_btn_up():
 		"only_visible_layers": _only_visible_layers_field().button_pressed,
 		"output_filename": _custom_name_field().text,
 		"do_not_create_resource": _do_not_create_res_field().button_pressed,
-		"remove_source_files_allowed": true,
 		"output_folder": output_location,
 	}
 	var exit_code = await _sf_creator.create_and_save_resources(

--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -46,7 +46,7 @@ func _get_import_order():
 func _get_import_options(_path, _i):
 	return [
 		{"name": "split_layers",           "default_value": false},
-		{"name": "exclude_layers_pattern", "default_value": ''},
+		{"name": "exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
 		{"name": "only_visible_layers",    "default_value": false},
 		{
 			"name": "sheet_type",

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -71,6 +71,7 @@ func _create_animations_from_file(animated_sprite: Node, options: Dictionary) ->
 
 	if _config.should_remove_source_files():
 		DirAccess.remove_absolute(output.content.data_file)
+		await _scan_filesystem()
 
 	return result_code.SUCCESS
 
@@ -115,7 +116,7 @@ func create_resources(source_file: String, options = {}) -> Dictionary:
 	if not result.is_ok:
 		return result
 
-	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()	
+	var should_remove_source = _config.should_remove_source_files()	
 
 	if should_remove_source:
 		_remove_source_files(result.content)
@@ -146,7 +147,7 @@ func _create_aseprite_output_files(source_file: String, options: Dictionary):
 
 
 func _create_sprite_frames_from_source(source_files: Array, options: Dictionary) -> Dictionary:
-	var should_remove_source = options.get("remove_source_files_allowed", false) and _config.should_remove_source_files()
+	var should_remove_source = _config.should_remove_source_files()
 
 	var resources = []
 

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -51,6 +51,7 @@ func _create_animations_from_file(target_node: Node, player: AnimationPlayer, op
 
 	if _config.should_remove_source_files():
 		DirAccess.remove_absolute(output.data_file)
+		await _scan_filesystem()
 
 	return result
 

--- a/addons/AsepriteWizard/config/config_dialog.tscn
+++ b/addons/AsepriteWizard/config/config_dialog.tscn
@@ -46,7 +46,7 @@ layout_mode = 2
 layout_mode = 2
 tooltip_text = "Define the path for Aseprite command"
 mouse_filter = 1
-text = "Aseprite Command Path3D"
+text = "Aseprite Command Path"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/VBoxContainer"]
 layout_mode = 2

--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,8 @@ config/icon="res://icon.png"
 [aseprite]
 
 wizard/history/cache_file_path=""
+animation/layers/exclusion_pattern="_$"
+import/import_plugin/enable_automatic_importer=true
 
 [editor_plugins]
 


### PR DESCRIPTION
Reported in #81 

- Use default exclusion pattern from project settings in the importer
- Remove legacy setting stopping JSON files from being removed

_Note: In Godot 4, I've seen some cases where the filesystem refresh happens faster than the file delete and the json file keeps showing in the fs dock even though it was excluded. That shouldn't happen too often_
