### PR TITLE
Add option to keep animations length on AnimationPlayer on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     - If not set, the animation will loop by default or follow whatever behaviour is set via the loop configuration from project settings.
     - If set, the plugin will repeat the animation n times and stop, like in Aseprite. This means you can disable looping by set repeat 1.
 - Support to ping-pong reverse animation direction.
+- Add option to keep animation length on import. Useful for when you have other properties manually defined in the animation and you want to keep its adjusted length.
+
 
 ### Thanks
 
 - Thanks to @chunhaqiushif for the repeat feature request.
+- Thanks to @Silvanuz for the "keep animation length" feature request.
 
 
 ## 6.1.1 (2023-03-22)

--- a/README.md
+++ b/README.md
@@ -74,21 +74,22 @@ Animations can be imported to AnimationPlayers via the Inspector dock.
 
 | Field                   | Description |
 | ----------------------- | ----------- |
-| Aseprite File: | (\*.aseprite or \*.ase) source file. |
-| Animation Player: |AnimationPlayer node where animations should be added to.|
-| Layer: | Aseprite layer to be used in the animation. By default, all layers are included. |
-| Output folder: | Folder to save the sprite sheet (png) file. Default: same as scene |
+| Aseprite File | (\*.aseprite or \*.ase) source file. |
+| Animation Player |AnimationPlayer node where animations should be added to.|
+| Layer | Aseprite layer to be used in the animation. By default, all layers are included. |
+| Output folder | Folder to save the sprite sheet (png) file. Default: same as scene |
 | Output file name | Output file name for the sprite sheet. In case the Layer option is used, this is used as file prefix (e.g prefix_layer_name.res). If not set, the source file basename is used.|
-| Exclude pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |
+| Exclude pattern | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |
+| Keep manual animation length | When this is active the animation length won't be adjusted if other properties were added and the resulting imported animation is shorter. Default: false. |
 | Only visible layers | If selected, it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 | Hide unused sprites | If selected, sprites that are present in the AnimationPlayer will be set as visible=false in any animation they are not part of.|
 
 
 Notes:
 - The generated sprite sheet texture is set to the Sprite node and every tag in the Aseprite file will be inserted as an Animation into the selected AnimationPlayer.
-- If the animation already exists in the AnimationPlayer, all existing tracks are kept. Only the required tracks for the Sprite animation will be changed (`Sprite:frame`).
-- Loop configuration and animation length will be changed according to the Aseprite file.
-- The plugin will never delete an Animation containing other tracks than the ones used by itself (i.e. `Sprite:frame`). In case the animation is removed from Aseprite, it will delete the track from the AnimationPlayer and only delete the animation in case there are no other tracks left.
+- If the animation already exists in the AnimationPlayer, all existing tracks are kept. Only the required tracks for the Sprite animation will be changed.
+- Loop configuration and animation length will be changed according to the Aseprite file. If you wish to keep a manually configured animation length, set the `Keep manual animation length` option.
+- The plugin will never delete an Animation containing other tracks than the ones used by itself. In case the animation is removed from Aseprite, it will delete the track from the AnimationPlayer and only delete the animation in case there are no other tracks left.
 - Animations are added to the global animation library by default. To define a library name, use the `library_name/animation_name` pattern on your Aseprite tags.
 
 ### AnimatedSprite and SpriteFrames

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -79,7 +79,7 @@ func _import(target_node: Node, player: AnimationPlayer, data: Dictionary, optio
 		target_node.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
 
 	_setup_texture(target_node, sprite_sheet, content, context)
-	var result = _configure_animations(target_node, player, content, context)
+	var result = _configure_animations(target_node, player, content, context, options.keep_anim_length)
 	if result != result_code.SUCCESS:
 		return result
 
@@ -92,7 +92,7 @@ func _load_texture(sprite_sheet: String) -> Texture2D:
 	return texture
 
 
-func _configure_animations(target_node: Node, player: AnimationPlayer, content: Dictionary, context: Dictionary):
+func _configure_animations(target_node: Node, player: AnimationPlayer, content: Dictionary, context: Dictionary, keep_anim_length: bool):
 	var frames = _aseprite.get_content_frames(content)
 
 	if not player.has_animation_library(_DEFAULT_ANIMATION_LIBRARY):
@@ -102,15 +102,15 @@ func _configure_animations(target_node: Node, player: AnimationPlayer, content: 
 		var result = result_code.SUCCESS
 		for tag in content.meta.frameTags:
 			var selected_frames = frames.slice(tag.from, tag.to + 1)
-			result = _add_animation_frames(target_node, player, tag.name, selected_frames, context, tag.direction, int(tag.get("repeat", -1)))
+			result = _add_animation_frames(target_node, player, tag.name, selected_frames, context, keep_anim_length, tag.direction, int(tag.get("repeat", -1)))
 			if result != result_code.SUCCESS:
 				break
 		return result
 	else:
-		return _add_animation_frames(target_node, player, "default", frames, context)
+		return _add_animation_frames(target_node, player, "default", frames, context, keep_anim_length)
 
 
-func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name: String, frames: Array, context: Dictionary, direction = 'forward', repeat = -1):
+func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name: String, frames: Array, context: Dictionary, keep_anim_length: bool, direction = 'forward', repeat = -1):
 	var animation_name = anim_name
 	var library_name = _DEFAULT_ANIMATION_LIBRARY
 	var is_loopable = _config.is_default_animation_loop_enabled()
@@ -181,7 +181,12 @@ func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name
 				animation.track_insert_key(frame_track_index, animation_length, frame_key)
 				animation_length += frame.duration / 1000
 
-	animation.length = animation_length
+	# if keep_anim_length is enabled only adjust length if
+	# - there aren't other tracks besides metas and frame
+	# - the current animation is shorter than new one
+	if not keep_anim_length or (animation.get_track_count() == (_get_meta_prop_names().size() + 1) or animation.length < animation_length):
+		animation.length = animation_length
+
 	animation.loop_mode = Animation.LOOP_LINEAR if is_loopable else Animation.LOOP_NONE
 
 	return result_code.SUCCESS
@@ -313,6 +318,13 @@ func _remove_properties_from_path(path: NodePath) -> NodePath:
 	return string_path as NodePath
 
 
+func _create_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
+	for prop in _get_meta_prop_names():
+		var track = _get_property_track_path(player, target_node, prop)
+		var track_index = _create_track(target_node, animation, track)
+		animation.track_insert_key(track_index, 0, true if prop == "visible" else target_node.get(prop))
+
+
 func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
 	push_error("_setup_texture not implemented!")
 
@@ -326,5 +338,5 @@ func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary):
 	push_error("_get_frame_key not implemented!")
 
 
-func _create_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
-	push_error("_create_meta_tracks not implemented!")
+func _get_meta_prop_names():
+	push_error("_get_meta_prop_names not implemented!")

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
@@ -37,6 +37,7 @@ var _layer_default := "[all]"
 @onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layers/CheckButton
 @onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
 @onready var _cleanup_hide_unused_nodes =  $margin/VBoxContainer/options/auto_visible_track/CheckButton
+@onready var _keep_length =  $margin/VBoxContainer/options/keep_length/CheckButton
 
 
 func _ready():
@@ -72,6 +73,7 @@ func _load_config(cfg):
 	_visible_layers_field.button_pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
 	_cleanup_hide_unused_nodes.button_pressed = cfg.get("set_vis_track", config.is_set_visible_track_automatically_enabled())
+	_keep_length.button_pressed = cfg.get("keep_anim_length", false)
 
 	_set_options_visible(cfg.get("op_exp", false))
 
@@ -189,6 +191,7 @@ func _on_import_pressed():
 		"output_folder": _output_folder if _output_folder != "" else root.scene_file_path.get_base_dir(),
 		"exception_pattern": _ex_pattern_field.text,
 		"only_visible_layers": _visible_layers_field.button_pressed,
+		"keep_anim_length": _keep_length.button_pressed,
 		"output_filename": _out_filename_field.text,
 		"cleanup_hide_unused_nodes": _cleanup_hide_unused_nodes.button_pressed,
 		"layer": _layer
@@ -210,6 +213,7 @@ func _save_config():
 		"o_name": _out_filename_field.text,
 		"only_visible": _visible_layers_field.button_pressed,
 		"o_ex_p": _ex_pattern_field.text,
+		"keep_anim_length": _keep_length.button_pressed,
 	}
 
 	if _cleanup_hide_unused_nodes.button_pressed != config.is_set_visible_track_automatically_enabled():

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
@@ -137,6 +137,21 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 
+[node name="keep_length" type="HBoxContainer" parent="margin/VBoxContainer/options"]
+layout_mode = 2
+tooltip_text = "When this is active the animation length won't be adjusted if other properties were added and the resulting imported animation is shorter."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/options/keep_length"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Keep manual animation length"
+
+[node name="CheckButton" type="CheckButton" parent="margin/VBoxContainer/options/keep_length"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+
 [node name="visible_layers" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 layout_mode = 2
 tooltip_text = "If active, layers not visible in the source file won't be included in the final image."

--- a/addons/AsepriteWizard/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/sprite_animation_creator.gd
@@ -1,5 +1,7 @@
 extends "animation_creator.gd"
 
+func _get_meta_prop_names():
+	return [ "texture", "hframes", "vframes", "visible" ]
 
 func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
 	var texture = _load_texture(sprite_sheet)
@@ -16,24 +18,6 @@ func _get_frame_property() -> String:
 	return "frame"
 
 
-func _create_meta_tracks(sprite: Node, player: AnimationPlayer, animation: Animation):
-	var texture_track = _get_property_track_path(player, sprite, "texture")
-	var texture_track_index = _create_track(sprite, animation, texture_track)
-	animation.track_insert_key(texture_track_index, 0, sprite.texture)
-
-	var hframes_track = _get_property_track_path(player, sprite, "hframes")
-	var hframes_track_index = _create_track(sprite, animation, hframes_track)
-	animation.track_insert_key(hframes_track_index, 0, sprite.hframes)
-
-	var vframes_track = _get_property_track_path(player, sprite, "vframes")
-	var vframes_track_index = _create_track(sprite, animation, vframes_track)
-	animation.track_insert_key(vframes_track_index, 0, sprite.vframes)
-
-	var visible_track = _get_property_track_path(player, sprite, "visible")
-	var visible_track_index = _create_track(sprite, animation, visible_track)
-	animation.track_insert_key(visible_track_index, 0, true)
-
-	
 func _get_frame_key(sprite:  Node, frame: Dictionary, context: Dictionary):
 	return _calculate_frame_index(sprite,frame)
 

--- a/addons/AsepriteWizard/animation_player/texture_rect_animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/texture_rect_animation_creator.gd
@@ -1,6 +1,10 @@
 extends "animation_creator.gd"
 
 
+func _get_meta_prop_names():
+	return [ "texture", "visible" ]
+
+
 func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
 	context["base_texture"] = _load_texture(sprite_sheet)
 
@@ -11,16 +15,6 @@ func _get_frame_property() -> String:
 
 func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary):
 	return _get_atlas_texture(context["base_texture"], frame)
-
-
-func _create_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
-	var texture_track = _get_property_track_path(player, target_node, "texture")
-	var texture_track_index = _create_track(target_node, animation, texture_track)
-	animation.track_insert_key(texture_track_index, 0, target_node.texture)
-
-	var visible_track = _get_property_track_path(player, target_node, "visible")
-	var visible_track_index = _create_track(target_node, animation, visible_track)
-	animation.track_insert_key(visible_track_index, 0, true)
 
 
 func _get_atlas_texture(base_texture: Texture2D, frame_data: Dictionary) -> AtlasTexture:


### PR DESCRIPTION
Add option to keep animation length on import. Useful for when you have other properties manually defined in the animation and you want to keep its adjusted length. 

Feature request #86 