### PR TITLE
Use frame duration in SpriteFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support to ping-pong reverse animation direction.
 - Add option to keep animation length on import. Useful for when you have other properties manually defined in the animation and you want to keep its adjusted length.
 
+### Changed
+
+- In SpriteFrames, for frames with longer duration, use the frame duration option introduced in Godot 4 instead of duplicating the frame.
 
 ### Thanks
 

--- a/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/animated_sprite/sprite_frames_creator.gd
@@ -315,10 +315,8 @@ func _add_to_sprite_frames(
 	frame_cache: Dictionary
 ):
 	var atlas : AtlasTexture = _create_atlastexture_from_frame(texture, frame, sprite_frames, frame_cache)
-
-	var number_of_sprites = ceil(frame.duration / min_duration)
-	for _i in range(number_of_sprites):
-		sprite_frames.add_frame(animation_name, atlas)
+	var duration = frame.duration / min_duration
+	sprite_frames.add_frame(animation_name, atlas, duration)
 
 
 func _create_atlastexture_from_frame(


### PR DESCRIPTION
When this plugin was implemented there was no option to set a duration for each frame in SpriteFrames. The workaround was to calculate the duration of the quickest frame and duplicate the ones with longer duration. i.e. smallest 50ms, a 200ms frame would be duplicated 4 times.

In Godot 4 a duration property was added to the frame so I'm changing the plugin to use that, which can potentially save space and prevent rounding issues.