### PR TITLE
Implement noop importer and improved import settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Added
+
+- New "No Import" importer. This allows managing Aseprite files in the filesystem dock without importing them as assets.
+- Default importer configuration in Project Settings.
+
+### Fixed
+
+- In ProjectSettings, default options were not hinted after any value was selected.
+- Fixed minor warnings related to ProjectSettings.
+
+### Removed
+
+- Removed the option to enable auto-importer. A default "No import" is enabled by default with the option to change it via ProjectSettings. For backwards compatibility the default option will be "SpriteFrames" in case the importer configuration was enabled.
+
 ## 6.2.0 (2023-07-10)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ For project specific configurations check `Project -> Project Settings -> Genera
 | Animation > Layer > Exclusion Pattern | Exclude layers with names matching this pattern (regex). This is the default value for new nodes. It can be changed or removed during the import. Default: not set |
 | Animation > Loop > Enabled | Enables animation loop by default. Default: `true` |
 | Animation > Loop > Exception prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The prefix is removed from the animation name on import (i.e  `_death` > `death`). Default: `_` |
-| Animation > Storage > Use metadata | Persist dock info in the scene metadata instead of editor description. Default: `true` |
+| Animation > Storage > Use metadata | (_deprecated_) Persist dock info in the scene metadata instead of editor description. Default: `true` |
 | Animation > Storage > Enable metadata removal on export | Removes dock metadata from scene when exporting the project. Ensures no local info is shipped with the app. Default: `true` |
 | Import > Preset > Enable Custom Preset | Enable Custom preset properties (*requires plugin restart*). Default: `false`. |
 | Import > Preset > Preset | Custom preset properties for texture files imported via this plugin. Default: same as Godot's defaults. |
 | Import > Cleanup > Remove Json File | Remove temporary `*.json` files generated during import. Default: `true` |
 | Import > Cleanup > Automatically Hide Sprites Not In Animation | Default configuration for AnimationPlayer option to hide Sprites when not in animation. Default: `false` |
-| Import > Import Plugin > Enable Automatic Importer | Enable/Disable Aseprite automatic importer (*requires plugin restart*). Default: `false` |
+| Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`. Default: `No Import` |
 | Wizard > History > Cache File Path | Path to file where history data is stored. Default: `res://.aseprite_wizard_history` |
 | Wizard > History > Keep One Entry Per Source File | When true, history does not show duplicates. Default: `false` |
 
@@ -144,9 +144,9 @@ Notes:
 
 If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project will be automatically imported as a `SpriteFrames` resource, which can be used in `AnimatedSprite` nodes. You can change import settings for each file in the Import dock.
 
-This feature needs to be enabled in the project settings. Requires editor restart.
+By default, the automatic importer won´t generate any file. You can change the default importer behaviour via Project Settings.
 
-### Options
+### SpriteFrames importer Options
 
 | Field                   | Description |
 | ----------------------- | ----------- |
@@ -187,8 +187,8 @@ If you imported animations via the inspector dock before version v5.2.0, you may
 
 From v5.2.0, this information is stored in the scene metadata and shouldn't be visible anymore. Any previously imported animation will still have the Editor Description info, but it will be moved to the metadata when re-imported again.
 
-You can disable the new behaviour at `Project > Project Settings > General > Animation > Storage > Use metadata`.
-
+You can disable the new behaviour at `Project > Project Settings > General > Animation > Storage > Use metadata`. _Keep in mind this will be deprecated in a next major version._
+ 
 As you can select files from anywhere in your system, there is an export plugin to prevent your local path metadata to be shipped with the game. In case you suspect this is conflicting with other plugins (or if you think you don't need it) you can disable it at `Project > Project Settings > General > Animation > Storage > Enable metadata removal on export`.
 
 ## Known Issues
@@ -213,6 +213,8 @@ You can workaround the issue by using an `AnimationPlayer` and splitting your an
 
 ## Contact
 
-Thanks for the constant feedback and suggestions. If you are facing problems with the plugin or have suggestions/questions, please open an issue in this repo or send me a message via [Twitter](https://twitter.com/vini_gerevini) or e-mail.
+Thanks for the constant feedback and suggestions. If you are facing problems with the plugin or have suggestions/questions, please open an issue in this repo.
 
 If you like game dev related content and want to support me, consider subscribing to my [Youtube channel](http://youtube.com/c/ThisIsVini).
+
+Check my [website](https://thisisvini.com) for more contact options.

--- a/addons/AsepriteWizard/animated_sprite/import_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/import_plugin.gd
@@ -8,6 +8,8 @@ var _sf_creator = preload("sprite_frames_creator.gd").new()
 var file_system: EditorFileSystem
 
 func _get_importer_name():
+	# ideally this should be called aseprite_wizard.plugin.spriteframes
+	# but I'm keeping it like this until next major release to avoid breaking changes
 	return "aseprite_wizard.plugin"
 
 
@@ -36,7 +38,7 @@ func _get_preset_name(i):
 
 
 func _get_priority():
-	return 1.0
+	return 2.0 if config.get_default_importer() == config.IMPORTER_SPRITEFRAMES_NAME else 1.0
 
 
 func _get_import_order():

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -26,6 +26,10 @@ const _SET_VISIBLE_TRACK_AUTOMATICALLY = 'aseprite/import/cleanup/automatically_
 
 # automatic importer
 const _IMPORTER_ENABLE_KEY = 'aseprite/import/import_plugin/enable_automatic_importer'
+const _DEFAULT_IMPORTER_KEY = 'aseprite/import/import_plugin/default_automatic_importer'
+
+const IMPORTER_SPRITEFRAMES_NAME = "SpriteFrames"
+const IMPORTER_NOOP_NAME = "No Import"
 
 # wizard history
 const _HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/cache_file_path'
@@ -65,10 +69,16 @@ func is_command_or_control_pressed() -> String:
 #######################################################
 # PROJECT SETTINGS
 ######################################################
+
+# remove this config in the next major version
 func is_importer_enabled() -> bool:
 	return _get_project_setting(_IMPORTER_ENABLE_KEY, false)
-	
-	
+
+
+func get_default_importer() -> String:
+	return _get_project_setting(_DEFAULT_IMPORTER_KEY, IMPORTER_SPRITEFRAMES_NAME if is_importer_enabled() else IMPORTER_NOOP_NAME)
+
+
 func is_exporter_enabled() -> bool:
 	return _get_project_setting(_EXPORTER_ENABLE_KEY, true)
 	
@@ -231,7 +241,13 @@ func initialize_project_settings():
 	_initialize_project_cfg(_IMPORT_PRESET_ENABLED, false, TYPE_BOOL)
 
 	_initialize_project_cfg(_REMOVE_SOURCE_FILES_KEY, true, TYPE_BOOL)
-	_initialize_project_cfg(_IMPORTER_ENABLE_KEY, false, TYPE_BOOL)
+	_initialize_project_cfg(
+		_DEFAULT_IMPORTER_KEY,
+		IMPORTER_NOOP_NAME if is_importer_enabled() else IMPORTER_SPRITEFRAMES_NAME,
+		TYPE_STRING,
+		PROPERTY_HINT_ENUM,
+		"%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME]
+	)
 	
 	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)
 
@@ -254,7 +270,7 @@ func clear_project_settings():
 		_IMPORT_PRESET_ENABLED,
 		_IMPORT_PRESET_KEY,
 		_REMOVE_SOURCE_FILES_KEY,
-		_IMPORTER_ENABLE_KEY,
+		_DEFAULT_IMPORTER_KEY,
 		_EXPORTER_ENABLE_KEY,
 		_HISTORY_CONFIG_FILE_CFG_KEY,
 		_HISTORY_SINGLE_ENTRY_KEY,
@@ -265,18 +281,22 @@ func clear_project_settings():
 	ProjectSettings.save()
 
 
-func _initialize_project_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE):
+func _initialize_project_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE, hint_string = null):
 	if not ProjectSettings.has_setting(key):
 		ProjectSettings.set(key, default_value)
-		ProjectSettings.set_initial_value(key, default_value)
-		ProjectSettings.add_property_info({
-			"name": key,
-			"type": type,
-			"hint": hint,
-		})
+	ProjectSettings.set_initial_value(key, default_value)
+	ProjectSettings.add_property_info({
+		"name": key,
+		"type": type,
+		"hint": hint,
+		"hint_string": hint_string,
+	})
 
 
 func _get_project_setting(key: String, default_value):
+	if not ProjectSettings.has_setting(key):
+		return default_value
+
 	var p = ProjectSettings.get(key)
 	return p if p != null else default_value
 
@@ -303,9 +323,9 @@ func create_import_file(data: Dictionary) -> void:
 func _initialize_editor_cfg(key: String, default_value, type: int, hint: int = PROPERTY_HINT_NONE):
 	if not _editor_settings.has_setting(key):
 		_editor_settings.set(key, default_value)
-		_editor_settings.set_initial_value(key, default_value, false)
-		_editor_settings.add_property_info({
-			"name": key,
-			"type": type,
-			"hint": hint,
-		})
+	_editor_settings.set_initial_value(key, default_value, false)
+	_editor_settings.add_property_info({
+		"name": key,
+		"type": type,
+		"hint": hint,
+	})

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -81,7 +81,7 @@ func get_default_importer() -> String:
 
 func is_exporter_enabled() -> bool:
 	return _get_project_setting(_EXPORTER_ENABLE_KEY, true)
-	
+
 
 func should_remove_source_files() -> bool:
 	return _get_project_setting(_REMOVE_SOURCE_FILES_KEY, true)
@@ -93,7 +93,7 @@ func is_default_animation_loop_enabled() -> bool:
 
 func get_animation_loop_exception_prefix() -> String:
 	return _get_project_setting(_LOOP_EXCEPTION_PREFIX, _DEFAULT_LOOP_EX_PREFIX)
-	
+
 func is_use_metadata_enabled() -> bool:
 	return _get_project_setting(_USE_METADATA, true)
 
@@ -248,7 +248,7 @@ func initialize_project_settings():
 		PROPERTY_HINT_ENUM,
 		"%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME]
 	)
-	
+
 	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)
 
 	_initialize_project_cfg(_HISTORY_CONFIG_FILE_CFG_KEY, _DEFAULT_HISTORY_CONFIG_FILE_PATH, TYPE_STRING, PROPERTY_HINT_GLOBAL_FILE)

--- a/addons/AsepriteWizard/noop_import_plugin.gd
+++ b/addons/AsepriteWizard/noop_import_plugin.gd
@@ -2,7 +2,7 @@
 extends EditorImportPlugin
 
 ##
-## No-op importer to allow files to be seen and 
+## No-op importer to allow files to be seen and
 ## managed, but without triggering a real import
 ##
 

--- a/addons/AsepriteWizard/noop_import_plugin.gd
+++ b/addons/AsepriteWizard/noop_import_plugin.gd
@@ -1,0 +1,58 @@
+@tool
+extends EditorImportPlugin
+
+##
+## No-op importer to allow files to be seen and 
+## managed, but without triggering a real import
+##
+
+var config
+var file_system: EditorFileSystem
+
+func _get_importer_name():
+	return "aseprite_wizard.plugin.noop"
+
+
+func _get_visible_name():
+	return "Aseprite (No Import)"
+
+
+func _get_recognized_extensions():
+	return ["aseprite", "ase"]
+
+
+func _get_save_extension():
+	return "res"
+
+
+func _get_resource_type():
+	return "PackedDataContainer"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_priority():
+	return 2.0 if config.get_default_importer() == config.IMPORTER_NOOP_NAME else 1.0
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_import_options(_path, _i):
+	return []
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _import(source_file, save_path, options, platform_variants, gen_files):
+	var container = PackedDataContainer.new()
+	return ResourceSaver.save(container, "%s.%s" % [save_path, _get_save_extension()])

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -68,7 +68,7 @@ func _setup_importer():
 	sprite_frames_import_plugin.file_system = get_editor_interface().get_resource_filesystem()
 	sprite_frames_import_plugin.config = config
 	add_import_plugin(sprite_frames_import_plugin)
-	
+
 	noop_import_plugin = NoopImportPlugin.new()
 	noop_import_plugin.config = config
 	add_import_plugin(noop_import_plugin)

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -3,7 +3,8 @@ extends EditorPlugin
 
 const ConfigDialog = preload('config/config_dialog.tscn')
 const WizardWindow = preload("animated_sprite/docks/as_wizard_dock_container.tscn")
-const ImportPlugin = preload("animated_sprite/import_plugin.gd")
+const SpriteFramesImportPlugin = preload("animated_sprite/import_plugin.gd")
+const NoopImportPlugin = preload("noop_import_plugin.gd")
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
 const AnimatedSpriteInspectorPlugin = preload("animated_sprite/inspector_plugin.gd")
 const SpriteInspectorPlugin = preload("animation_player/inspector_plugin.gd")
@@ -13,12 +14,12 @@ const config_menu_item_name = "Aseprite Wizard Config"
 var config = preload("config/config.gd").new()
 var window: TabContainer
 var config_window: PopupPanel
-var import_plugin : EditorImportPlugin
+var sprite_frames_import_plugin : EditorImportPlugin
+var noop_import_plugin : EditorImportPlugin
 var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
 
-var _importer_enabled = false
 var _exporter_enabled = false
 
 
@@ -63,12 +64,14 @@ func _remove_menu_entries():
 
 
 func _setup_importer():
-	if config.is_importer_enabled():
-		import_plugin = ImportPlugin.new()
-		import_plugin.file_system = get_editor_interface().get_resource_filesystem()
-		import_plugin.config = config
-		add_import_plugin(import_plugin)
-		_importer_enabled = true
+	sprite_frames_import_plugin = SpriteFramesImportPlugin.new()
+	sprite_frames_import_plugin.file_system = get_editor_interface().get_resource_filesystem()
+	sprite_frames_import_plugin.config = config
+	add_import_plugin(sprite_frames_import_plugin)
+	
+	noop_import_plugin = NoopImportPlugin.new()
+	noop_import_plugin.config = config
+	add_import_plugin(noop_import_plugin)
 
 
 func _configure_preset():
@@ -77,10 +80,9 @@ func _configure_preset():
 
 
 func _remove_importer():
-	if _importer_enabled:
-		remove_import_plugin(import_plugin)
-		_importer_enabled = false
-		
+	remove_import_plugin(sprite_frames_import_plugin)
+	remove_import_plugin(noop_import_plugin)
+
 
 func _setup_exporter():
 	if config.is_exporter_enabled():

--- a/project.godot
+++ b/project.godot
@@ -16,9 +16,7 @@ config/icon="res://icon.png"
 
 [aseprite]
 
-wizard/history/cache_file_path=""
-animation/layers/exclusion_pattern="_$"
-import/import_plugin/enable_automatic_importer=true
+import/import_plugin/default_automatic_importer="No Import"
 
 [editor_plugins]
 


### PR DESCRIPTION
Adding a new "No import" importer and removing the "enable importer" setting. This allows Aseprite files to be managed via File system dock and also features like the one suggested in #97 .

The default importer can be selected via Project Settings:

![Screenshot from 2023-10-13 09-17-50](https://github.com/viniciusgerevini/godot-aseprite-wizard/assets/4930052/64a78ccf-9114-40ea-afb9-177ed92a214c)

It can also be for each file via import dock:

![Screenshot from 2023-10-13 09-17-31](https://github.com/viniciusgerevini/godot-aseprite-wizard/assets/4930052/2cb6093a-afac-4d27-a697-690cdc7b3d1f)

Godot already comes with a "No import" option, however as of now there is no way to set what is the default importer for a file, so I had to include our own option for that.

This PR also fixes minor issues with ProjectSettings and default options.
