### PR TITLE
Implement Tileset importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - New "No Import" importer. This allows managing Aseprite files in the filesystem dock without importing them as assets.
 - Default importer configuration in Project Settings.
+- Tileset automatic importer. With this importer you can use any aseprite file directly in the Tileset editor.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@ _Check the screenshots folder for more examples._
 
 ### Features
 
-- Import animations to AnimationPlayer, AnimatedSprite2D, AnimatedSprite3D or SpriteFrames resource.
 - Godot importer and inspector docks for easy import and re-import.
-- Filters out layers you don't want in the final animation using regex.
+- Adds automatic importers:
+    - Aseprite SpriteFrames: Use aseprite files as SpriteFrames resources.
+    - Aseprite Tileset Texture: Use aseprite files with tilemap layers as AtlasTexture which can be added directly to Godot's tileset creator.
+- Inspector docks to manually import animations to:
+    - AnimationPlayer (Sprite2D, Sprite3D and TextureRect).
+    - AnimatedSprite2D/3D.
+    - As standalone SpritesFrames resource.
 - Supports Aseprite animation directions (forward, reverse, ping-pong, ping-pong reverse).
 - Supports loopable and non-loopable animations via Aseprite repeat or tags.
 - Separates each Aseprite Tag into animations. In case no tags are defined, imports everything as default animation.
-- AnimatedSprite
+- Filters out layers you don't want in the final animation using regex.
+- For AnimatedSprite
   - Creates SpriteFrames with Atlas Texture to be used in AnimatedSprites.
   - Converts Aseprite frame duration (defined in milliseconds) to Godot's animation FPS. This way you can create your animation with the right timing in Aseprite and it should work the same way in Godot.
   - Choose to export the Aseprite file as a single SpriteFrames resource or separate each layer in different resources.
@@ -53,7 +59,7 @@ For project specific configurations check `Project -> Project Settings -> Genera
 | Import > Preset > Preset | Custom preset properties for texture files imported via this plugin. Default: same as Godot's defaults. |
 | Import > Cleanup > Remove Json File | Remove temporary `*.json` files generated during import. Default: `true` |
 | Import > Cleanup > Automatically Hide Sprites Not In Animation | Default configuration for AnimationPlayer option to hide Sprites when not in animation. Default: `false` |
-| Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`. Default: `No Import` |
+| Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`, `Tileset Texture`. Default: `No Import` |
 | Wizard > History > Cache File Path | Path to file where history data is stored. Default: `res://.aseprite_wizard_history` |
 | Wizard > History > Keep One Entry Per Source File | When true, history does not show duplicates. Default: `false` |
 
@@ -61,7 +67,11 @@ For project specific configurations check `Project -> Project Settings -> Genera
 
 _Check this video for usage examples:_ https://youtu.be/1W-CCbrzG_0
 
-After activating the plugin, you can find a section called Aseprite in the inspector dock when selecting Sprite and AnimatedSprite nodes. Also, the importer will be enabled allowing Aseprite files to be used seamlessly. In addition to that, you can find the wizard screen on `Project -> Tools -> Aseprite Spritesheet Wizard` menu.
+After activating the plugin, there are three different ways you can use it:
+
+1. Using the automatic importers: Any file saved in the project will be automatically converted to the chosen resource. By default, the importer does not import anything. You can change the behaviour per file or choose the default importer via Project Settings.
+1. Using the inspector docks: There will be a section called Aseprite in the inspector dock when selecting Sprite, TextureRect and AnimatedSprite nodes.
+1. Using the wizard dock: You can open the wizard dock via `Project -> Tools -> Aseprite Spritesheet Wizard` menu. In this dock you can generate standalone SpriteFrames files from anywhere in your system.
 
 ### AnimationPlayer
 
@@ -120,7 +130,7 @@ Notes:
 - As opposed to the AnimationPlayer flow, a new SpriteFrames resource is generated on every import. This means any manual change will be lost after re-import.
 
 
-### Wizard (bottom dock)
+#### Wizard (bottom dock)
 
 The wizard screen allows you to import SpriteFrames resources without attaching them to a scene or node This can be used in cases where you would like to generate SpriteFrames independently and include them in different nodes manually or programmatically.
 
@@ -140,13 +150,13 @@ Notes:
 - Overwrites any manual change done to previously imported resources.
 
 
-### Importer
+#### Importer
 
 If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project will be automatically imported as a `SpriteFrames` resource, which can be used in `AnimatedSprite` nodes. You can change import settings for each file in the Import dock.
 
 By default, the automatic importer won´t generate any file. You can change the default importer behaviour via Project Settings.
 
-### SpriteFrames importer Options
+SpriteFrames importer Options:
 
 | Field                   | Description |
 | ----------------------- | ----------- |
@@ -154,6 +164,21 @@ By default, the automatic importer won´t generate any file. You can change the 
 | Exclude layers matching pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Split layers in multiple resources: | If selected, each layer will be exported as a separated resource (e.g my_layer_1.res, layer_name_2.res, ...). If not selected, all layers will be merged and exported as a single resource file with the same base name as the source. |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+
+
+### Tilesets
+
+Aseprite 1.3 added [Tilemap support](https://www.aseprite.org/docs/tilemap/). You can create special layers which can then be exported as tilesets. Aseprite Wizard has an automatic importer which allows using asprite files directly in the Tileset editor in Godot.
+
+You can select the "Aseprite Tileset Texture Importer" in the Import dock. You can also set it as the default importer via ProjectSettings.
+
+Tileset importer options:
+
+| Field                   | Description |
+| ----------------------- | ----------- |
+| Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
+| Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+
 
 ## F.A.Q. and limitations
 

--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -67,10 +67,10 @@ func _import(target_node: Node, player: AnimationPlayer, data: Dictionary, optio
 	var test_json_conv = JSON.new()
 	test_json_conv.parse(file.get_as_text())
 	var content =  test_json_conv.get_data()
-	
+
 	if not _aseprite.is_valid_spritesheet(content):
 		return result_code.ERR_INVALID_ASEPRITE_SPRITESHEET
-	
+
 	var context = {}
 
 	if target_node is CanvasItem:
@@ -84,7 +84,7 @@ func _import(target_node: Node, player: AnimationPlayer, data: Dictionary, optio
 		return result
 
 	return _cleanup_animations(target_node, player, content, options)
-	
+
 
 func _load_texture(sprite_sheet: String) -> Texture2D:
 	var texture = ResourceLoader.load(sprite_sheet, 'Image', ResourceLoader.CACHE_MODE_IGNORE)
@@ -123,7 +123,7 @@ func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name
 	elif anim_tokens.size() == 2:
 		library_name = anim_tokens[0]
 		animation_name = anim_tokens[1]
-		
+
 	if not _validate_animation_name(animation_name):
 		push_error("Invalid animation name: %s" % animation_name)
 		return
@@ -266,7 +266,7 @@ func _hide_unused_nodes(target_node: Node, player: AnimationPlayer, content: Dic
 
 		for track_idx in animation.get_track_count():
 			var raw_path := animation.track_get_path(track_idx)
-			
+
 			if raw_path.get_subname(0) == "visible":
 				continue
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -67,7 +67,7 @@ func export_layer(file_name: String, layer_name: String, output_folder: String, 
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 	arguments.push_front(layer_name)
 	arguments.push_front("--layer")
-	
+
 	_add_sheet_type_arguments(arguments, options)
 
 	var exit_code = _execute(arguments, output)
@@ -129,7 +129,7 @@ func list_layers(file_name: String, only_visible = false) -> Array:
 
 	if output.is_empty():
 		return output
-	
+
 	var raw = output[0].split('\n')
 	var sanitized = []
 	for s in raw:

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -185,3 +185,47 @@ func is_valid_spritesheet(content):
 
 func get_content_frames(content):
 	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
+
+
+##
+## Exports tileset layers
+##
+## Return (dictionary):
+##      sprite_sheet: localized path to spritesheet file
+func export_tileset_texture(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
+	var exception_pattern = options.get('exception_pattern', "")
+	var only_visible_layers = options.get('only_visible_layers', false)
+	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename', file_name)
+	var basename = _get_file_basename(output_name)
+	var output_dir = ProjectSettings.globalize_path(output_folder)
+	var data_path = "%s/%s.json" % [output_dir, basename]
+	var sprite_sheet = "%s/%s.png" % [output_dir, basename]
+	var output = []
+
+	var arguments = [
+		"-b",
+		"--export-tileset",
+		"--data",
+		data_path,
+		"--format",
+		"json-array",
+		"--sheet",
+		sprite_sheet,
+		file_name
+	]
+
+	if not only_visible_layers:
+		arguments.push_front("--all-layers")
+
+	_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
+
+	var exit_code = _execute(arguments, output)
+	if exit_code != 0:
+		printerr('aseprite: failed to export spritesheet')
+		printerr(output)
+		return {}
+
+	return {
+		"data_file": ProjectSettings.localize_path(data_path),
+		"sprite_sheet": ProjectSettings.localize_path(sprite_sheet)
+	}

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -191,6 +191,7 @@ func get_content_frames(content):
 ## Exports tileset layers
 ##
 ## Return (dictionary):
+##      data_file: path to aseprite generated JSON file
 ##      sprite_sheet: localized path to spritesheet file
 func export_tileset_texture(file_name: String, output_folder: String, options: Dictionary) -> Dictionary:
 	var exception_pattern = options.get('exception_pattern', "")

--- a/addons/AsepriteWizard/base_sprite_resource_creator.gd
+++ b/addons/AsepriteWizard/base_sprite_resource_creator.gd
@@ -1,0 +1,51 @@
+@tool
+extends RefCounted
+
+var result_code = preload("config/result_codes.gd")
+var _aseprite = preload("aseprite/aseprite.gd").new()
+
+var _config
+var _file_system: EditorFileSystem
+
+##
+## Load initial dependencies
+##
+func init(config, editor_file_system: EditorFileSystem = null):
+	_config = config
+	_file_system = editor_file_system
+	_aseprite.init(config)
+
+
+##
+## Perform initial source file and output folder checks
+##
+func _initial_checks(source: String, options: Dictionary) -> int:
+	if not _aseprite.test_command():
+		return result_code.ERR_ASEPRITE_CMD_NOT_FOUND
+
+	if not FileAccess.file_exists(source):
+		return result_code.ERR_SOURCE_FILE_NOT_FOUND
+
+	if not DirAccess.dir_exists_absolute(options.output_folder):
+		return result_code.ERR_OUTPUT_FOLDER_NOT_FOUND
+
+	return result_code.SUCCESS
+
+
+##
+## Load Aseprite source data file and fails if the
+## content is not valid
+##
+func _load_json_content(source_file: String) -> Dictionary:
+	var file = FileAccess.open(source_file, FileAccess.READ)
+	if file == null:
+		return result_code.error(file.get_open_error())
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(file.get_as_text())
+
+	var content = test_json_conv.get_data()
+
+	if not _aseprite.is_valid_spritesheet(content):
+		return result_code.error(result_code.ERR_INVALID_ASEPRITE_SPRITESHEET)
+
+	return result_code.result(content)

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -30,6 +30,7 @@ const _DEFAULT_IMPORTER_KEY = 'aseprite/import/import_plugin/default_automatic_i
 
 const IMPORTER_SPRITEFRAMES_NAME = "SpriteFrames"
 const IMPORTER_NOOP_NAME = "No Import"
+const TILESET_TEXTURE_NAME = "Tileset Texture"
 
 # wizard history
 const _HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/cache_file_path'
@@ -246,7 +247,7 @@ func initialize_project_settings():
 		IMPORTER_NOOP_NAME if is_importer_enabled() else IMPORTER_SPRITEFRAMES_NAME,
 		TYPE_STRING,
 		PROPERTY_HINT_ENUM,
-		"%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME]
+		"%s,%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME, TILESET_TEXTURE_NAME]
 	)
 
 	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -5,6 +5,7 @@ const ConfigDialog = preload('config/config_dialog.tscn')
 const WizardWindow = preload("animated_sprite/docks/as_wizard_dock_container.tscn")
 const SpriteFramesImportPlugin = preload("animated_sprite/import_plugin.gd")
 const NoopImportPlugin = preload("noop_import_plugin.gd")
+const TilesetTextureImportPlugin = preload("tileset/tileset_texture_import_plugin.gd")
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
 const AnimatedSpriteInspectorPlugin = preload("animated_sprite/inspector_plugin.gd")
 const SpriteInspectorPlugin = preload("animation_player/inspector_plugin.gd")
@@ -16,6 +17,7 @@ var window: TabContainer
 var config_window: PopupPanel
 var sprite_frames_import_plugin : EditorImportPlugin
 var noop_import_plugin : EditorImportPlugin
+var tileset_texture_import_plugin : EditorImportPlugin
 var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
@@ -73,6 +75,11 @@ func _setup_importer():
 	noop_import_plugin.config = config
 	add_import_plugin(noop_import_plugin)
 
+	tileset_texture_import_plugin = TilesetTextureImportPlugin.new()
+	tileset_texture_import_plugin.file_system = get_editor_interface().get_resource_filesystem()
+	tileset_texture_import_plugin.config = config
+	add_import_plugin(tileset_texture_import_plugin)
+
 
 func _configure_preset():
 	if config.is_import_preset_enabled():
@@ -82,6 +89,7 @@ func _configure_preset():
 func _remove_importer():
 	remove_import_plugin(sprite_frames_import_plugin)
 	remove_import_plugin(noop_import_plugin)
+	remove_import_plugin(tileset_texture_import_plugin)
 
 
 func _setup_exporter():

--- a/addons/AsepriteWizard/tileset/tileset_texture_creator.gd
+++ b/addons/AsepriteWizard/tileset/tileset_texture_creator.gd
@@ -1,0 +1,24 @@
+@tool
+extends "../base_sprite_resource_creator.gd"
+
+func generate_aseprite_spritesheet(source_file: String, options = {}) -> Dictionary:
+	var check = _initial_checks(source_file, options)
+
+	if check != result_code.SUCCESS:
+		printerr(result_code.get_error_message(check))
+		return result_code.error(check)
+
+	var output = _aseprite.export_tileset_texture(source_file, options.output_folder, options)
+
+	if output.is_empty():
+		printerr(result_code.get_error_message(result_code.ERR_ASEPRITE_EXPORT_FAILED))
+		return result_code.error(check)
+
+	var data = _load_json_content(output.data_file)
+
+	if not data.is_ok:
+		return data
+
+	output.data = data.content
+
+	return result_code.result(output)

--- a/addons/AsepriteWizard/tileset/tileset_texture_creator.gd
+++ b/addons/AsepriteWizard/tileset/tileset_texture_creator.gd
@@ -1,6 +1,21 @@
 @tool
 extends "../base_sprite_resource_creator.gd"
 
+##
+## Generate a spritesheet with all tilesets in the file
+##
+## Options:
+##    exception_pattern (string)
+##    only_visible_layers (boolean)
+##    output_filename (string)
+##    output_folder (string)
+##
+## Return:
+##  Dictionary
+##     sprite_sheet: sprite sheet path
+##     data_file:  json file path
+##     data: content of aseprite json file
+##
 func generate_aseprite_spritesheet(source_file: String, options = {}) -> Dictionary:
 	var check = _initial_checks(source_file, options)
 

--- a/addons/AsepriteWizard/tileset/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/tileset/tileset_texture_import_plugin.gd
@@ -1,0 +1,107 @@
+@tool
+extends EditorImportPlugin
+
+##
+## Tileset texture importer.
+## Imports Aseprite tileset layers as a AtlasTexture
+##
+
+const result_codes = preload("../config/result_codes.gd")
+
+var _texture_creator = preload("tileset_texture_creator.gd").new()
+var config
+var file_system: EditorFileSystem
+
+
+func _get_importer_name():
+	return "aseprite_wizard.plugin.tileset-texture"
+
+
+func _get_visible_name():
+	return "Aseprite Tileset Texture"
+
+
+func _get_recognized_extensions():
+	return ["aseprite", "ase"]
+
+
+func _get_save_extension():
+	return "res"
+
+
+func _get_resource_type():
+	return "AtlasTexture"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_priority():
+	return 2.0 if config.get_default_importer() == config.TILESET_TEXTURE_NAME else 0.9
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_import_options(_path, _i):
+	return [
+		{"name": "exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
+		{"name": "only_visible_layers",    "default_value": false},
+	]
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _import(source_file, save_path, options, platform_variants, gen_files):
+	var absolute_source_file = ProjectSettings.globalize_path(source_file)
+	var absolute_save_path = ProjectSettings.globalize_path(save_path)
+
+	var source_path = source_file.substr(0, source_file.rfind('/'))
+	var source_basename = source_file.substr(source_path.length()+1, -1)
+	source_basename = source_basename.substr(0, source_basename.rfind('.'))
+
+	_texture_creator.init(config, file_system)
+
+	var aseprite_opts = {
+		"exception_pattern": options['exclude_layers_pattern'],
+		"only_visible_layers": options['only_visible_layers'],
+		"output_filename": '',
+		"output_folder": source_path,
+	}
+
+	var result = await _texture_creator.generate_aseprite_spritesheet(absolute_source_file, aseprite_opts)
+
+	if not result.is_ok:
+		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(result.code))
+		return FAILED
+
+	var sprite_sheet = result.content.sprite_sheet
+
+	file_system.update_file(sprite_sheet)
+	append_import_external_resource(sprite_sheet)
+
+	var texture: CompressedTexture2D = ResourceLoader.load(sprite_sheet, "CompressedTexture2D", ResourceLoader.CACHE_MODE_REPLACE)
+	var resource = AtlasTexture.new()
+	resource.atlas = texture
+	resource.region = Rect2(0, 0, result.content.data.meta.size.w, result.content.data.meta.size.h)
+
+	var resource_path = "%s.res" % save_path
+	var exit_code = ResourceSaver.save(resource, resource_path)
+	resource.take_over_path(resource_path)
+
+	if config.should_remove_source_files():
+		DirAccess.remove_absolute(result.content.data_file)
+		file_system.call_deferred("scan")
+
+	if exit_code != OK:
+		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		return FAILED
+	return OK

--- a/project.godot
+++ b/project.godot
@@ -14,10 +14,6 @@ config/name="AsepriteWizard"
 config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
-[aseprite]
-
-import/import_plugin/default_automatic_importer="No Import"
-
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/AsepriteWizard/plugin.cfg")


### PR DESCRIPTION
Aseprite 1.3 added [Tilemap support](https://www.aseprite.org/docs/tilemap/). You can create special layers which can then be exported as tilesets. This implementation adds an automatic importer which allows using asprite files directly in the Tileset editor in Godot.

You can select the "Aseprite Tileset Texture Importer" in the Import dock. You can also set it as the default importer via ProjectSettings.

Tileset importer options:

| Field                   | Description |
| ----------------------- | ----------- |
| Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
| Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|