### PR TITLE
Drag and drop support in dock fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - New "No Import" importer. This allows managing Aseprite files in the filesystem dock without importing them as assets.
 - Default importer configuration in Project Settings.
 - Tileset automatic importer. With this importer you can use any aseprite file directly in the Tileset editor.
+- Drag-and-drop support to dock fields:
+    - source file: can drop ase and aseprite from FileSystem dock
+    - Animation Player: can drop AnimationPlayer nodes from Scene dock
+    - Output folder: can drop directories from FileSystem dock
 
 ### Changed
 
@@ -20,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - In ProjectSettings, default options were not hinted after any value was selected.
 - Fixed minor warnings related to ProjectSettings.
+- Animated sprites source field didn´t open dialogue in current folder
 
 ### Removed
 
@@ -29,7 +34,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Thanks
 
-- Thanks @poohcom1 for for the EditorFileDialog tip
+- Thanks @russmatney for the drag-and-drop implementation
+- Thanks @poohcom1 for the EditorFileDialog tip
 
 
 ## 6.2.0 (2023-07-10)

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd
@@ -51,8 +51,7 @@ func _load_config(cfg):
 		_layer_field.clear()
 		_set_layer(cfg.layer)
 
-	_output_folder = cfg.get("o_folder", "")
-	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
+	_set_out_folder(cfg.get("o_folder", ""))
 	_out_filename_field.text = cfg.get("o_name", "")
 	_visible_layers_field.button_pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
@@ -166,7 +165,7 @@ func _open_source_dialog():
 	_file_dialog_aseprite = _create_aseprite_file_selection()
 	get_parent().add_child(_file_dialog_aseprite)
 	if _source != "":
-		_file_dialog_aseprite.current_dir = _source.get_base_dir()
+		_file_dialog_aseprite.current_dir = ProjectSettings.globalize_path(_source.get_base_dir())
 	_file_dialog_aseprite.popup_centered_ratio()
 
 
@@ -220,6 +219,20 @@ func _create_output_folder_selection():
 
 
 func _on_output_folder_selected(path):
+	_set_out_folder(path)
+	_output_folder_dialog.queue_free()
+
+
+func _on_source_aseprite_file_dropped(path):
+	_set_source(path)
+	_save_config()
+
+
+func _on_out_dir_dropped(path):
+	_set_out_folder(path)
+
+
+func _set_out_folder(path):
 	_output_folder = path
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
-	_output_folder_dialog.queue_free()
+	_out_folder_field.tooltip_text = _out_folder_field.text

--- a/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://vej7yqkbtd5f"]
+[gd_scene load_steps=4 format=3 uid="uid://vej7yqkbtd5f"]
 
 [ext_resource type="Script" path="res://addons/AsepriteWizard/animated_sprite/docks/animated_sprite_inspector_dock.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://dj1uo3blocr8e" path="res://addons/AsepriteWizard/shared/source_drop_button.tscn" id="2_qlnhy"]
+[ext_resource type="PackedScene" uid="uid://cwvgnm3o7eed2" path="res://addons/AsepriteWizard/shared/dir_drop_button.tscn" id="3_qxvub"]
 
 [node name="animated_sprite_inspector_dock" type="PanelContainer"]
 offset_right = 14.0
@@ -33,12 +35,8 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Aseprite File"
 
-[node name="button" type="Button" parent="margin/VBoxContainer/source"]
+[node name="button" parent="margin/VBoxContainer/source" instance=ExtResource("2_qlnhy")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "[empty]"
-clip_text = true
 
 [node name="layer" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
@@ -81,12 +79,8 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Output folder"
 
-[node name="button" type="Button" parent="margin/VBoxContainer/options/out_folder"]
+[node name="button" parent="margin/VBoxContainer/options/out_folder" instance=ExtResource("3_qxvub")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "[empty]"
-clip_text = true
 
 [node name="out_filename" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 layout_mode = 2
@@ -137,9 +131,11 @@ size_flags_stretch_ratio = 2.0
 layout_mode = 2
 text = "Import"
 
+[connection signal="aseprite_file_dropped" from="margin/VBoxContainer/source/button" to="." method="_on_source_aseprite_file_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
 [connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
+[connection signal="dir_dropped" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_dir_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]
 [connection signal="pressed" from="margin/VBoxContainer/import" to="." method="_on_import_pressed"]

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd
@@ -69,8 +69,7 @@ func _load_config(cfg):
 		_layer_field.clear()
 		_set_layer(cfg.layer)
 
-	_output_folder = cfg.get("o_folder", "")
-	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
+	_set_out_folder(cfg.get("o_folder", ""))
 	_out_filename_field.text = cfg.get("o_name", "")
 	_visible_layers_field.button_pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
@@ -300,6 +299,33 @@ func _create_output_folder_selection():
 
 
 func _on_output_folder_selected(path):
+	_set_out_folder(path)
+	_output_folder_dialog.queue_free()
+
+
+func _on_source_aseprite_file_dropped(path):
+	_set_source(path)
+	_save_config()
+
+
+func _on_animation_player_node_dropped(node_path):
+	var node = get_node(node_path)
+	var root = get_tree().get_edited_scene_root()
+
+	_animation_player_path = root.get_path_to(node)
+
+	for i in range(_options_field.get_item_count()):
+		if _options_field.get_item_text(i) == _animation_player_path:
+			_options_field.select(i)
+			break
+	_save_config()
+
+
+func _on_out_dir_dropped(path):
+	_set_out_folder(path)
+
+
+func _set_out_folder(path):
 	_output_folder = path
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
-	_output_folder_dialog.queue_free()
+	_out_folder_field.tooltip_text = _out_folder_field.text

--- a/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.tscn
@@ -1,6 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://biyshalfalqqw"]
+[gd_scene load_steps=5 format=3 uid="uid://biyshalfalqqw"]
 
 [ext_resource type="Script" path="res://addons/AsepriteWizard/animation_player/docks/animation_player_inspector_dock.gd" id="1"]
+[ext_resource type="PackedScene" uid="uid://x1f1t87m582u" path="res://addons/AsepriteWizard/shared/animation_player_drop_button.tscn" id="2_nfeqc"]
+[ext_resource type="PackedScene" uid="uid://dj1uo3blocr8e" path="res://addons/AsepriteWizard/shared/source_drop_button.tscn" id="2_pj0v0"]
+[ext_resource type="PackedScene" uid="uid://cwvgnm3o7eed2" path="res://addons/AsepriteWizard/shared/dir_drop_button.tscn" id="4_jb8bn"]
 
 [node name="sprite_inspector_dock" type="PanelContainer"]
 offset_right = 14.0
@@ -33,14 +36,8 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "AnimationPlayer"
 
-[node name="options" type="OptionButton" parent="margin/VBoxContainer/animation_player"]
+[node name="options" parent="margin/VBoxContainer/animation_player" instance=ExtResource("2_nfeqc")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-item_count = 1
-selected = 0
-popup/item_0/text = "[empty]"
-popup/item_0/id = 0
 
 [node name="source" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
@@ -52,12 +49,8 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Aseprite File"
 
-[node name="button" type="Button" parent="margin/VBoxContainer/source"]
+[node name="button" parent="margin/VBoxContainer/source" instance=ExtResource("2_pj0v0")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "[empty]"
-clip_text = true
 
 [node name="layer" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
@@ -100,12 +93,8 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Output folder"
 
-[node name="button" type="Button" parent="margin/VBoxContainer/options/out_folder"]
+[node name="button" parent="margin/VBoxContainer/options/out_folder" instance=ExtResource("4_jb8bn")]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "[empty]"
-clip_text = true
 
 [node name="out_filename" type="HBoxContainer" parent="margin/VBoxContainer/options"]
 layout_mode = 2
@@ -188,9 +177,12 @@ text = "Import"
 
 [connection signal="button_down" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_item_selected"]
+[connection signal="node_dropped" from="margin/VBoxContainer/animation_player/options" to="." method="_on_animation_player_node_dropped"]
+[connection signal="aseprite_file_dropped" from="margin/VBoxContainer/source/button" to="." method="_on_source_aseprite_file_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
 [connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
+[connection signal="dir_dropped" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_dir_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]
 [connection signal="pressed" from="margin/VBoxContainer/import" to="." method="_on_import_pressed"]

--- a/addons/AsepriteWizard/shared/animation_player_drop_button.gd
+++ b/addons/AsepriteWizard/shared/animation_player_drop_button.gd
@@ -1,0 +1,15 @@
+@tool
+extends Button
+
+signal node_dropped(node_path)
+
+func _can_drop_data(_pos, data):
+	if data.type == "nodes":
+		var node = get_node(data.nodes[0])
+		return node is AnimationPlayer
+	return false
+
+
+func _drop_data(_pos, data):
+	var path = data.nodes[0]
+	node_dropped.emit(path)

--- a/addons/AsepriteWizard/shared/animation_player_drop_button.tscn
+++ b/addons/AsepriteWizard/shared/animation_player_drop_button.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3 uid="uid://x1f1t87m582u"]
+
+[ext_resource type="Script" path="res://addons/AsepriteWizard/shared/animation_player_drop_button.gd" id="1_tfmxw"]
+
+[node name="options" type="OptionButton"]
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+item_count = 1
+selected = 0
+popup/item_0/text = "[empty]"
+popup/item_0/id = 0
+script = ExtResource("1_tfmxw")

--- a/addons/AsepriteWizard/shared/dir_drop_button.gd
+++ b/addons/AsepriteWizard/shared/dir_drop_button.gd
@@ -1,0 +1,16 @@
+@tool
+extends Button
+
+signal dir_dropped(path)
+
+# TODO files_and_dirs
+func _can_drop_data(_pos, data):
+	print(data)
+	if data.type == "files_and_dirs":
+		var dir_access = DirAccess.open(data.files[0])
+		return dir_access != null
+	return false
+
+
+func _drop_data(_pos, data):
+	dir_dropped.emit(data.files[0])

--- a/addons/AsepriteWizard/shared/dir_drop_button.tscn
+++ b/addons/AsepriteWizard/shared/dir_drop_button.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://cwvgnm3o7eed2"]
+
+[ext_resource type="Script" path="res://addons/AsepriteWizard/shared/dir_drop_button.gd" id="1_7uqph"]
+
+[node name="button" type="Button"]
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "[empty]"
+clip_text = true
+script = ExtResource("1_7uqph")

--- a/addons/AsepriteWizard/shared/source_drop_button.gd
+++ b/addons/AsepriteWizard/shared/source_drop_button.gd
@@ -1,0 +1,15 @@
+@tool
+extends Button
+
+signal aseprite_file_dropped(path)
+
+func _can_drop_data(_pos, data):
+	if data.type == "files":
+		var extension = data.files[0].get_extension()
+		return extension == "ase" or extension == "aseprite"
+	return false
+
+
+func _drop_data(_pos, data):
+	var path = data.files[0]
+	aseprite_file_dropped.emit(path)

--- a/addons/AsepriteWizard/shared/source_drop_button.tscn
+++ b/addons/AsepriteWizard/shared/source_drop_button.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://dj1uo3blocr8e"]
+
+[ext_resource type="Script" path="res://addons/AsepriteWizard/shared/source_drop_button.gd" id="1_smfgi"]
+
+[node name="source_drop_button" type="Button"]
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "[empty]"
+clip_text = true
+script = ExtResource("1_smfgi")


### PR DESCRIPTION
As suggested and instructed in #97 

- Source file: can receive `.ase` and `.aseprite` files from FileSystem dock
- Animation Player: can receive AnimationPlayer nodes from Scene dock
- Output folder: can receive directories from FileSystem dock