### PR TITLE
Fix loop exception detection for animation in a library

### DIFF
--- a/addons/AsepriteWizard/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/animation_player/animation_creator.gd
@@ -83,7 +83,7 @@ func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name
 
 	# Check loop
 	if animation_name.begins_with(_config.get_animation_loop_exception_prefix()):
-		animation_name = anim_name.substr(_config.get_animation_loop_exception_prefix().length())
+		animation_name = animation_name.substr(_config.get_animation_loop_exception_prefix().length())
 		is_loopable = not is_loopable
 
 	# Add library


### PR DESCRIPTION
Found this minor bug; using a prefix for a loop exception breaks when the animation is in a library (i.e. `attack/_a`). The substring logic uses the full animation name (`anim_name`) rather than the base animation name (`animation_name`), so the name gets reverted to full name, creating an invalid animation.

Haven't had a chance to fully test it, but I applied this patch for my project and so far it's working well.