### PR TITLE
Fix _get_name error caused by metadata_export_plugin.gd

### DIFF
--- a/addons/AsepriteWizard/export/metadata_export_plugin.gd
+++ b/addons/AsepriteWizard/export/metadata_export_plugin.gd
@@ -2,6 +2,10 @@ extends EditorExportPlugin
 
 const wizard_config = preload("../config/wizard_config.gd")
 
+func _get_name():
+	return "aseprite_wizard_metadata_export_plugin"
+
+
 func _export_file(path: String, type: String, features: PackedStringArray) -> void:
 	if type != "PackedScene": return
 


### PR DESCRIPTION
EditorExportPlugin need _get_name override for sorting usage. this change aims to fix the corresponding error message when export game