### PR TITLE
Allow importing aseprite file as static image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ _Check the screenshots folder for more examples._
 
 - Godot importer and inspector docks for easy import and re-import.
 - Adds automatic importers:
-    - Aseprite SpriteFrames: Use aseprite files as SpriteFrames resources.
-    - Aseprite Tileset Texture: Use aseprite files with tilemap layers as AtlasTexture which can be added directly to Godot's tileset creator.
+	- Aseprite SpriteFrames: Use aseprite files as SpriteFrames resources.
+	- Aseprite Texture: Use aseprite files as static images (only first frame is imported)
+	- Aseprite Tileset Texture: Use aseprite files with tilemap layers as AtlasTexture which can be added directly to Godot's tileset creator.
 - Inspector docks to manually import animations to:
-    - AnimationPlayer (Sprite2D, Sprite3D and TextureRect).
-    - AnimatedSprite2D/3D.
-    - As standalone SpritesFrames resource.
+	- AnimationPlayer (Sprite2D, Sprite3D and TextureRect).
+	- AnimatedSprite2D/3D.
+	- As standalone SpritesFrames resource.
 - Supports Aseprite animation directions (forward, reverse, ping-pong, ping-pong reverse).
 - Supports loopable and non-loopable animations via Aseprite repeat or tags.
 - Separates each Aseprite Tag into animations. In case no tags are defined, imports everything as default animation.
@@ -36,7 +37,6 @@ _Check the screenshots folder for more examples._
   - Supports animation libraries.
 
 Aseprite Wizard is only required during development. If you decide to not use it anymore, you can remove the plugin and all animations previously imported should keep working as expected.
-
 
 ## Installation and Configuration
 
@@ -59,7 +59,7 @@ For project specific configurations check `Project -> Project Settings -> Genera
 | Animation > Storage > Enable metadata removal on export | Removes dock metadata from scene when exporting the project. Ensures no local info is shipped with the app. Default: `true` |
 | Import > Cleanup > Remove Json File | Remove temporary `*.json` files generated during import. Default: `true` |
 | Import > Cleanup > Automatically Hide Sprites Not In Animation | Default configuration for AnimationPlayer option to hide Sprites when not in animation. Default: `false` |
-| Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`, `Tileset Texture`. Default: `No Import` |
+| Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`, `Static Texture`, `Tileset Texture`. Default: `No Import` |
 | Wizard > History > Cache File Path | Path to file where history data is stored. Default: `res://.aseprite_wizard_history` |
 | Wizard > History > Keep One Entry Per Source File | When true, history does not show duplicates. Default: `false` |
 
@@ -179,6 +179,31 @@ Tileset importer options:
 | Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 
+### Static image (AtlasTexture)
+
+You can import your Aseprite file as a static image (first frame only, no animations) via the inspector dock or automatic importer.
+
+For the inspector dock, after selecting a `Sprite` or `TextureRect` node, in the Aseprite section you can select "mode" as "Image".
+
+Dock options:
+
+| Field                   | Description |
+| ----------------------- | ----------- |
+| Aseprite File | (\*.aseprite or \*.ase) source file. |
+| Layer | Aseprite layer to be used in the animation. By default, all layers are included. |
+| Output folder | Folder to save the sprite sheet (png) file. Default: same as scene |
+| Output file name | Output file name for the sprite sheet. In case the Layer option is used, this is used as file prefix (e.g prefix_layer_name.res). If not set, the source file basename is used.|
+| Exclude pattern | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |
+| Only visible layers | If selected, it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+
+You can also use Aseprite files directly as static images. For that you need to select the "Aseprite Texture" importer in the Import dock. You can also set it as the default importer via ProjectSettings.
+
+Texture importer options:
+
+| Field                   | Description |
+| ----------------------- | ----------- |
+| Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
+| Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 
 ## F.A.Q. and limitations
 
@@ -213,7 +238,7 @@ If you imported animations via the inspector dock before version v5.2.0, you may
 From v5.2.0, this information is stored in the scene metadata and shouldn't be visible anymore. Any previously imported animation will still have the Editor Description info, but it will be moved to the metadata when re-imported again.
 
 You can disable the new behaviour at `Project > Project Settings > General > Animation > Storage > Use metadata`. _Keep in mind this will be deprecated in a next major version._
- 
+
 As you can select files from anywhere in your system, there is an export plugin to prevent your local path metadata to be shipped with the game. In case you suspect this is conflicting with other plugins (or if you think you don't need it) you can disable it at `Project > Project Settings > General > Animation > Storage > Enable metadata removal on export`.
 
 ## Known Issues

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -16,6 +16,7 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 	var exception_pattern = options.get('exception_pattern', "")
 	var only_visible_layers = options.get('only_visible_layers', false)
 	var output_name = file_name if options.get('output_filename') == "" else options.get('output_filename', file_name)
+	var first_frame_only = options.get("first_frame_only", false)
 	var basename = _get_file_basename(output_name)
 	var output_dir = ProjectSettings.globalize_path(output_folder)
 	var data_file = "%s/%s.json" % [output_dir, basename]
@@ -25,6 +26,10 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 
 	if not only_visible_layers:
 		arguments.push_front("--all-layers")
+
+	if first_frame_only:
+		arguments.push_front("'[0, 0]'")
+		arguments.push_front("--frame-range")
 
 	_add_sheet_type_arguments(arguments, options)
 
@@ -67,10 +72,15 @@ func export_layer(file_name: String, layer_name: String, output_folder: String, 
 	var output_dir = output_folder.replace("res://", "./").strip_edges()
 	var data_file = "%s/%s%s.json" % [output_dir, output_prefix, layer_name]
 	var sprite_sheet = "%s/%s%s.png" % [output_dir, output_prefix, layer_name]
+	var first_frame_only = options.get("first_frame_only", false)
 	var output = []
 	var arguments = _export_command_common_arguments(file_name, data_file, sprite_sheet)
 	arguments.push_front(layer_name)
 	arguments.push_front("--layer")
+
+	if first_frame_only:
+		arguments.push_front("'[0, 0]'")
+		arguments.push_front("--frame-range")
 
 	_add_sheet_type_arguments(arguments, options)
 

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -26,7 +26,8 @@ const _DEFAULT_IMPORTER_KEY = 'aseprite/import/import_plugin/default_automatic_i
 
 const IMPORTER_SPRITEFRAMES_NAME = "SpriteFrames"
 const IMPORTER_NOOP_NAME = "No Import"
-const TILESET_TEXTURE_NAME = "Tileset Texture"
+const IMPORTER_TILESET_TEXTURE_NAME = "Tileset Texture"
+const IMPORTER_STATIC_TEXTURE_NAME = "Static Texture"
 
 # wizard history
 const _HISTORY_CONFIG_FILE_CFG_KEY = 'aseprite/wizard/history/cache_file_path'
@@ -223,7 +224,7 @@ func initialize_project_settings():
 		IMPORTER_SPRITEFRAMES_NAME if is_importer_enabled() else IMPORTER_NOOP_NAME,
 		TYPE_STRING,
 		PROPERTY_HINT_ENUM,
-		"%s,%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME, TILESET_TEXTURE_NAME]
+		"%s,%s,%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME, IMPORTER_TILESET_TEXTURE_NAME, IMPORTER_STATIC_TEXTURE_NAME]
 	)
 
 	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -15,7 +15,7 @@ func _get_importer_name():
 
 
 func _get_visible_name():
-	return "Aseprite SpriteFrames Importer"
+	return "Aseprite SpriteFrames"
 
 
 func _get_recognized_extensions():

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -2,8 +2,8 @@
 extends EditorImportPlugin
 
 ##
-## Tileset texture importer.
-## Imports Aseprite tileset layers as an AtlasTexture
+## Static texture importer.
+## Imports first frame from Aseprite file as texture
 ##
 
 const result_codes = preload("../config/result_codes.gd")
@@ -14,11 +14,11 @@ var file_system: EditorFileSystem
 
 
 func _get_importer_name():
-	return "aseprite_wizard.plugin.tileset-texture"
+	return "aseprite_wizard.plugin.static-texture"
 
 
 func _get_visible_name():
-	return "Aseprite Tileset Texture"
+	return "Aseprite Texture"
 
 
 func _get_recognized_extensions():
@@ -42,7 +42,7 @@ func _get_preset_name(i):
 
 
 func _get_priority():
-	return 2.0 if config.get_default_importer() == config.IMPORTER_TILESET_TEXTURE_NAME else 0.9
+	return 2.0 if config.get_default_importer() == config.IMPORTER_STATIC_TEXTURE_NAME else 0.8
 
 
 func _get_import_order():
@@ -74,6 +74,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		"only_visible_layers": options['only_visible_layers'],
 		"output_filename": '',
 		"output_folder": source_path,
+		"first_frame_only": true,
 	}
 
 	var result = _generate_texture(absolute_source_file, aseprite_opts)
@@ -97,7 +98,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 
 func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dictionary:
-	var result = _aseprite_file_exporter.generate_tileset_files(absolute_source_file, options)
+	var result = _aseprite_file_exporter.generate_aseprite_file(absolute_source_file, options)
 
 	if not result.is_ok:
 		return result

--- a/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.gd
@@ -46,7 +46,9 @@ var _layer_default := "[all]"
 @onready var _out_filename_field = $margin/VBoxContainer/options/out_filename/LineEdit
 @onready var _visible_layers_field =  $margin/VBoxContainer/options/visible_layers/CheckButton
 @onready var _ex_pattern_field = $margin/VBoxContainer/options/ex_pattern/LineEdit
+@onready var _cleanup_hide_unused_nodes_container =  $margin/VBoxContainer/options/auto_visible_track
 @onready var _cleanup_hide_unused_nodes =  $margin/VBoxContainer/options/auto_visible_track/CheckButton
+@onready var _keep_length_container =  $margin/VBoxContainer/options/keep_length
 @onready var _keep_length =  $margin/VBoxContainer/options/keep_length/CheckButton
 
 
@@ -126,8 +128,12 @@ func _handle_import_mode():
 	match _import_mode:
 		ImportMode.ANIMATION:
 			_animation_player_container.show()
+			_keep_length_container.show()
+			_cleanup_hide_unused_nodes_container.show()
 		ImportMode.IMAGE:
 			_animation_player_container.hide()
+			_keep_length_container.hide()
+			_cleanup_hide_unused_nodes_container.hide()
 
 
 func _on_options_button_down():

--- a/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.gd
@@ -9,6 +9,11 @@ const AnimationCreator = preload("../../../creators/animation_player/animation_c
 const SpriteAnimationCreator = preload("../../../creators/animation_player/sprite_animation_creator.gd")
 const TextureRectAnimationCreator = preload("../../../creators/animation_player/texture_rect_animation_creator.gd")
 
+enum ImportMode {
+	ANIMATION = 0,
+	IMAGE = 1
+}
+
 var animation_creator: AnimationCreator
 
 var scene: Node
@@ -16,6 +21,8 @@ var target_node: Node
 
 var config
 var file_system: EditorFileSystem
+
+var _import_mode = -1
 
 var _layer: String = ""
 var _source: String = ""
@@ -28,7 +35,9 @@ var _output_folder := ""
 var _out_folder_default := "[Same as scene]"
 var _layer_default := "[all]"
 
+@onready var _import_mode_options_field = $margin/VBoxContainer/modes/options
 @onready var _options_field = $margin/VBoxContainer/animation_player/options
+@onready var _animation_player_container = $margin/VBoxContainer/animation_player
 @onready var _source_field = $margin/VBoxContainer/source/button
 @onready var _layer_field = $margin/VBoxContainer/layer/options
 @onready var _options_title = $margin/VBoxContainer/options_title/options_title
@@ -78,6 +87,8 @@ func _load_config(cfg):
 
 	_set_options_visible(cfg.get("op_exp", false))
 
+	_set_import_mode(int(cfg.get("i_mode", 0)))
+
 
 func _load_default_config():
 	_ex_pattern_field.text = config.get_default_exclusion_pattern()
@@ -99,6 +110,24 @@ func _set_animation_player(player):
 func _set_layer(layer):
 	_layer = layer
 	_layer_field.add_item(_layer)
+
+
+func _set_import_mode(import_mode):
+	if _import_mode == import_mode:
+		return
+
+	_import_mode = import_mode
+	var index = _import_mode_options_field.get_item_index(import_mode)
+	_import_mode_options_field.select(index)
+	_handle_import_mode()
+
+
+func _handle_import_mode():
+	match _import_mode:
+		ImportMode.ANIMATION:
+			_animation_player_container.show()
+		ImportMode.IMAGE:
+			_animation_player_container.hide()
 
 
 func _on_options_button_down():
@@ -144,18 +173,7 @@ func _on_layer_button_down():
 		return
 
 	var layers = animation_creator.list_layers(ProjectSettings.globalize_path(_source))
-	var current = 0
-	_layer_field.clear()
-	_layer_field.add_item("[all]")
-
-	for l in layers:
-		if l == "":
-			continue
-
-		_layer_field.add_item(l)
-		if l == _layer:
-			current = _layer_field.get_item_count() - 1
-	_layer_field.select(current)
+	_populate_options_field(_layer_field, layers, _layer)
 
 
 func _on_layer_item_selected(index):
@@ -175,6 +193,17 @@ func _on_import_pressed():
 		return
 	_importing = true
 
+	if _import_mode == ImportMode.IMAGE:
+		_import_static()
+		return
+
+	_import_for_animation_player()
+
+##
+## Import aseprite animations to target AnimationPlayer and set
+## spritesheet as the node's texture
+##
+func _import_for_animation_player():
 	var root = get_tree().get_edited_scene_root()
 
 	if _animation_player_path == "" or not root.has_node(_animation_player_path):
@@ -188,22 +217,15 @@ func _on_import_pressed():
 		return
 
 	var source_path = ProjectSettings.globalize_path(_source)
-	var options = {
-		"output_folder": _output_folder if _output_folder != "" else root.scene_file_path.get_base_dir(),
-		"exception_pattern": _ex_pattern_field.text,
-		"only_visible_layers": _visible_layers_field.button_pressed,
-		"output_filename": _out_filename_field.text,
-		"layer": _layer
-	}
+
+	var options = _get_import_options(root.scene_file_path.get_base_dir())
 
 	_save_config()
 
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source_path, options)
 
 	if not aseprite_output.is_ok:
-		var error = result_code.get_error_message(aseprite_output.code)
-		printerr(error)
-		_show_message(error)
+		_notify_aseprite_error(aseprite_output.code)
 		return
 
 	file_system.scan()
@@ -217,13 +239,48 @@ func _on_import_pressed():
 	animation_creator.create_animations(target_node, root.get_node(_animation_player_path), aseprite_output.content, anim_options)
 	_importing = false
 
-	if config.should_remove_source_files():
-		DirAccess.remove_absolute(aseprite_output.content.data_file)
-		file_system.call_deferred("scan")
+	_handle_cleanup(aseprite_output.content)
+
+##
+## Import first frame from aseprite file as node texture
+##
+func _import_static():
+	if _source == "":
+		_show_message("Aseprite file not selected")
+		_importing = false
+		return
+
+	var source_path = ProjectSettings.globalize_path(_source)
+	var root = get_tree().get_edited_scene_root()
+
+	var options = _get_import_options(root.scene_file_path.get_base_dir())
+	options["first_frame_only"] = true
+
+	_save_config()
+
+	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source_path, options)
+
+	if not aseprite_output.is_ok:
+		_notify_aseprite_error(aseprite_output.code)
+		return
+
+	file_system.scan()
+	await file_system.filesystem_changed
+
+	var sprite_sheet = aseprite_output.content.sprite_sheet
+	target_node.texture = ResourceLoader.load(sprite_sheet)
+	_importing = false
+
+	_adjust_target_node_texture_filter()
+	_handle_cleanup(aseprite_output.content)
 
 
+##
+## Save current import options to node metadata
+##
 func _save_config():
 	var cfg := {
+		"i_mode": _import_mode,
 		"player": _animation_player_path,
 		"source": _source,
 		"layer": _layer,
@@ -329,3 +386,54 @@ func _set_out_folder(path):
 	_output_folder = path
 	_out_folder_field.text = _output_folder if _output_folder != "" else _out_folder_default
 	_out_folder_field.tooltip_text = _out_folder_field.text
+
+
+func _on_modes_item_selected(index):
+	var id = _import_mode_options_field.get_item_id(index)
+	_import_mode = id
+	_handle_import_mode()
+
+
+## Helper method to populate field with values
+func _populate_options_field(field: OptionButton, values: Array, current_name: String):
+	var current = 0
+	field.clear()
+	field.add_item("[all]")
+
+	for v in values:
+		if v == "":
+			continue
+
+		field.add_item(v)
+		if v == current_name:
+			current = field.get_item_count() - 1
+	field.select(current)
+
+
+func _handle_cleanup(aseprite_content):
+	if config.should_remove_source_files():
+		DirAccess.remove_absolute(aseprite_content.data_file)
+		file_system.call_deferred("scan")
+
+
+func _notify_aseprite_error(aseprite_error_code):
+	var error = result_code.get_error_message(aseprite_error_code)
+	printerr(error)
+	_show_message(error)
+
+
+func _adjust_target_node_texture_filter():
+	if target_node is CanvasItem:
+		target_node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	else:
+		target_node.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
+
+
+func _get_import_options(default_folder: String):
+	return {
+		"output_folder": _output_folder if _output_folder != "" else default_folder,
+		"exception_pattern": _ex_pattern_field.text,
+		"only_visible_layers": _visible_layers_field.button_pressed,
+		"output_filename": _out_filename_field.text,
+		"layer": _layer
+	}

--- a/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
@@ -26,6 +26,28 @@ size_flags_horizontal = 3
 text = "Aseprite"
 horizontal_alignment = 1
 
+[node name="modes" type="HBoxContainer" parent="margin/VBoxContainer"]
+layout_mode = 2
+tooltip_text = "Import mode.
+Animation mode (default): set spritesheet as texture and imports animations to the selected AnimationPlayer.
+Image mode: Import only first frame and set as texture."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/modes"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Mode"
+
+[node name="options" type="OptionButton" parent="margin/VBoxContainer/modes"]
+layout_mode = 2
+size_flags_horizontal = 3
+item_count = 2
+selected = 0
+popup/item_0/text = "Animation"
+popup/item_0/id = 0
+popup/item_1/text = "Image"
+popup/item_1/id = 1
+
 [node name="animation_player" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
 tooltip_text = "AnimationPlayer  node where animations should be added to."
@@ -175,6 +197,7 @@ size_flags_stretch_ratio = 2.0
 layout_mode = 2
 text = "Import"
 
+[connection signal="item_selected" from="margin/VBoxContainer/modes/options" to="." method="_on_modes_item_selected"]
 [connection signal="button_down" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/animation_player/options" to="." method="_on_options_item_selected"]
 [connection signal="node_dropped" from="margin/VBoxContainer/animation_player/options" to="." method="_on_animation_player_node_dropped"]

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -5,6 +5,8 @@ extends EditorPlugin
 const NoopImportPlugin = preload("importers/noop_import_plugin.gd")
 const SpriteFramesImportPlugin = preload("importers/sprite_frames_import_plugin.gd")
 const TilesetTextureImportPlugin = preload("importers/tileset_texture_import_plugin.gd")
+const TextureImportPlugin = preload("importers/static_texture_import_plugin.gd")
+
 # export
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
 # interface
@@ -19,15 +21,13 @@ const config_menu_item_name = "Aseprite Wizard Config"
 var config = preload("config/config.gd").new()
 var window: TabContainer
 var config_window: PopupPanel
-var sprite_frames_import_plugin : EditorImportPlugin
-var noop_import_plugin : EditorImportPlugin
-var tileset_texture_import_plugin : EditorImportPlugin
 var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
 
 var _exporter_enabled = false
 
+var _importers = []
 
 func _enter_tree():
 	_load_config()
@@ -69,25 +69,23 @@ func _remove_menu_entries():
 
 
 func _setup_importer():
-	sprite_frames_import_plugin = SpriteFramesImportPlugin.new()
-	sprite_frames_import_plugin.file_system = get_editor_interface().get_resource_filesystem()
-	sprite_frames_import_plugin.config = config
-	add_import_plugin(sprite_frames_import_plugin)
+	_importers = [
+		NoopImportPlugin.new(),
+		SpriteFramesImportPlugin.new(),
+		TilesetTextureImportPlugin.new(),
+		TextureImportPlugin.new(),
+	]
 
-	noop_import_plugin = NoopImportPlugin.new()
-	noop_import_plugin.config = config
-	add_import_plugin(noop_import_plugin)
-
-	tileset_texture_import_plugin = TilesetTextureImportPlugin.new()
-	tileset_texture_import_plugin.file_system = get_editor_interface().get_resource_filesystem()
-	tileset_texture_import_plugin.config = config
-	add_import_plugin(tileset_texture_import_plugin)
+	for i in _importers:
+		if not i is NoopImportPlugin:
+			i.file_system = get_editor_interface().get_resource_filesystem()
+		i.config = config
+		add_import_plugin(i)
 
 
 func _remove_importer():
-	remove_import_plugin(sprite_frames_import_plugin)
-	remove_import_plugin(noop_import_plugin)
-	remove_import_plugin(tileset_texture_import_plugin)
+	for i in _importers:
+		remove_import_plugin(i)
 
 
 func _setup_exporter():


### PR DESCRIPTION
#113 

- Added "mode" to `Sprite` and `TextureRect` inspect dock. This allows importing Aseprite files as Animations (as it is today) or Images (static texture).
- Added Aseprite Texture importer automatic importer, which allows using Aseprite files as static images directly.