### PR TITLE
Internal rename to prevent shadowing issues in godot 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+## Changed
+
+- Changed docks internal import variable name to prevent shadowing native class that will be introduced on Godot 3.6.
+
 ## 6.2.0 (2023-10-24)
 
 ### Added

--- a/addons/AsepriteWizard/animated_sprite/inspector_plugin.gd
+++ b/addons/AsepriteWizard/animated_sprite/inspector_plugin.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorInspectorPlugin
 
-const InspectorDock = preload("./docks/animated_sprite_inspector_dock.tscn")
+const AsepriteInspectorDock = preload("./docks/animated_sprite_inspector_dock.tscn")
 
 var config
 var file_system: EditorFileSystem
@@ -16,7 +16,7 @@ func parse_begin(object):
 
 
 func parse_end():
-	var dock = InspectorDock.instance()
+	var dock = AsepriteInspectorDock.instance()
 	dock.sprite = _sprite
 	dock.config = config
 	dock.file_system = file_system

--- a/addons/AsepriteWizard/animation_player/inspector_plugin.gd
+++ b/addons/AsepriteWizard/animation_player/inspector_plugin.gd
@@ -1,7 +1,7 @@
 tool
 extends EditorInspectorPlugin
 
-const InspectorDock = preload("./docks/animation_player_inspector_dock.tscn")
+const AsepriteInspectorDock = preload("./docks/animation_player_inspector_dock.tscn")
 
 var config
 var file_system: EditorFileSystem
@@ -16,7 +16,7 @@ func parse_begin(object):
 
 
 func parse_end():
-	var dock = InspectorDock.instance()
+	var dock = AsepriteInspectorDock.instance()
 	dock.target_node = _target_node
 	dock.config = config
 	dock.file_system = file_system


### PR DESCRIPTION
Changed docks internal import variable name to prevent shadowing native class that will be introduced on Godot 3.6.

#120 