### PR TITLE
Do not include unnecessary tracks in AnimationPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Default config for "include only visible layers".
 
+### Changed
+
+- Does not include extra tracks in AnimationPlayer.
+
 ### Fixed
 
 - "Do not create source" in wizard dock was not being applied (@mpewsey)
@@ -16,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Thanks @jefvel for default visible layers feature request.
 - Thanks @mpewsey for finding and fixing the "create resource" config bug.
+- Thanks @feelingsonice for raising the extra tags discussion.
 
 ## 7.1.0 (2023-12-13)
 

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -263,10 +263,19 @@ func _remove_properties_from_path(path: NodePath) -> NodePath:
 
 
 func _create_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
+	_cleanup_meta_tracks(target_node, player, animation)
 	for prop in _get_meta_prop_names():
 		var track = _get_property_track_path(player, target_node, prop)
 		var track_index = _create_track(target_node, animation, track)
 		animation.track_insert_key(track_index, 0, true if prop == "visible" else target_node.get(prop))
+
+
+func _cleanup_meta_tracks(target_node: Node, player: AnimationPlayer, animation: Animation):
+	for track_key in ["texture", "hframes", "vframes"]:
+		var track = _get_property_track_path(player, target_node, track_key)
+		var track_index = animation.find_track(track, Animation.TYPE_VALUE)
+		if track_index != -1:
+			animation.remove_track(track_index)
 
 
 func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -241,7 +241,7 @@ func _hide_unused_nodes(target_node: Node, player: AnimationPlayer, content: Dic
 			if sprite_nodes.has(node):
 				continue
 			var visible_track = _get_property_track_path(player, node, "visible")
-			if animation.find_track(visible_track) != -1:
+			if animation.find_track(visible_track, Animation.TYPE_VALUE) != -1:
 				continue
 			var visible_track_index = _create_track(node, animation, visible_track)
 			animation.track_insert_key(visible_track_index, 0, false)

--- a/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
@@ -1,7 +1,7 @@
 extends "animation_creator.gd"
 
 func _get_meta_prop_names():
-	return [ "texture", "hframes", "vframes", "visible" ]
+	return [ "visible" ]
 
 func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
 	var texture = _load_texture(sprite_sheet)

--- a/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
@@ -3,6 +3,7 @@ extends "animation_creator.gd"
 func _get_meta_prop_names():
 	return [ "visible" ]
 
+
 func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
 	var texture = _load_texture(sprite_sheet)
 	sprite.texture = texture

--- a/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
@@ -2,7 +2,7 @@ extends "animation_creator.gd"
 
 
 func _get_meta_prop_names():
-	return [ "texture", "visible" ]
+	return [ "visible" ]
 
 
 func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="AsepriteWizard"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [aseprite]


### PR DESCRIPTION
Do not add unnecessary tracks to AnimationPlayer. #118

The "visible" track is still required due to how the "hide unused" option works. I'll re-write that bit as the behaviour is weird sometimes and I might be able to remove "visible" when not used.