### PR TITLE
fix: resolve issue retrieving open error

### DIFF
--- a/addons/AsepriteWizard/aseprite/file_exporter.gd
+++ b/addons/AsepriteWizard/aseprite/file_exporter.gd
@@ -135,7 +135,7 @@ func _initial_checks(source: String, options: Dictionary) -> int:
 func load_json_content(source_file: String) -> Dictionary:
 	var file = FileAccess.open(source_file, FileAccess.READ)
 	if file == null:
-		return result_code.error(file.get_open_error())
+		return result_code.error(FileAccess.get_open_error())
 	var test_json_conv = JSON.new()
 	test_json_conv.parse(file.get_as_text())
 


### PR DESCRIPTION
Description
----
This pull request fixes an issue when the plugin is unable to open a file, when the aseprite file generated bad data.

Current behaviour:
```
  res://addons/AsepriteWizard/aseprite/file_exporter.gd:138 - Attempt to call function 'get_open_error' in base 'null instance' on a null instance.
  res://addons/AsepriteWizard/creators/animation_player/animation_creator.gd:18 - Invalid get index 'is_ok' (on base: 'Dictionary').
  res://addons/AsepriteWizard/creators/animation_player/animation_creator.gd:10 - Invalid type in function 'get_error_message' in base 'GDScript'. Cannot convert argument 1 from Nil to int.
```

Expected behaviour:
```
aseprite generated bad data file
```