### PR TITLE
Slice support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+## Added
+
+- Slice support.
+
 ## 7.2.0 (2024-02-07)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Animations can be imported to AnimationPlayers via the Inspector dock.
 | Aseprite File | (\*.aseprite or \*.ase) source file. |
 | Animation Player |AnimationPlayer node where animations should be added to.|
 | Layer | Aseprite layer to be used in the animation. By default, all layers are included. |
+| Slice | Aseprite Slice to be used in the animation. By default, the whole file is used. |
 | Output folder | Folder to save the sprite sheet (png) file. Default: same as scene |
 | Output file name | Output file name for the sprite sheet. In case the Layer option is used, this is used as file prefix (e.g prefix_layer_name.res). If not set, the source file basename is used.|
 | Exclude pattern | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |
@@ -120,6 +121,7 @@ This is very similar to the AnimationPlayer option.
 | Aseprite File: | (\*.aseprite or \*.ase) source file. |
 | Animation Player: |AnimationPlayer node where animations should be added to.|
 | Layer: | Aseprite layer to be used in the animation. By default, all layers are included. |
+| Slice | Aseprite Slice to be used in the animation. By default, the whole file is used. |
 | Output folder: | Folder to save the sprite sheet (png) file. Default: same as scene |
 | Output file name | Output file name for the sprite sheet. In case the Layer option is used, this is used as the file prefix (e.g prefix_layer_name.res). If not set, the source file basename is used.|
 | Exclude pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |
@@ -192,6 +194,7 @@ Dock options:
 | ----------------------- | ----------- |
 | Aseprite File | (\*.aseprite or \*.ase) source file. |
 | Layer | Aseprite layer to be used in the animation. By default, all layers are included. |
+| Slice | Aseprite Slice to be used in the animation. By default, the whole file is used. |
 | Output folder | Folder to save the sprite sheet (png) file. Default: same as scene |
 | Output file name | Output file name for the sprite sheet. In case the Layer option is used, this is used as file prefix (e.g prefix_layer_name.res). If not set, the source file basename is used.|
 | Exclude pattern | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html) |

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -155,10 +155,32 @@ func list_layers(file_name: String, only_visible = false) -> Array:
 	return sanitized
 
 
+func list_slices(file_name: String) -> Array:
+	var output = []
+	var arguments = ["-b", "--list-slices", file_name]
+
+	var exit_code = _execute(arguments, output)
+
+	if exit_code != 0:
+		printerr('aseprite: failed listing slices')
+		printerr(output)
+		return []
+
+	if output.is_empty():
+		return output
+
+	var raw = output[0].split('\n')
+	var sanitized = []
+	for s in raw:
+		sanitized.append(s.strip_edges())
+	return sanitized
+
+
 func _export_command_common_arguments(source_name: String, data_path: String, spritesheet_path: String) -> Array:
 	return [
 		"-b",
 		"--list-tags",
+		"--list-slices",
 		"--data",
 		data_path,
 		"--format",
@@ -203,6 +225,17 @@ func is_valid_spritesheet(content):
 
 func get_content_frames(content):
 	return content.frames if typeof(content.frames) == TYPE_ARRAY  else content.frames.values()
+
+
+func get_slice_rect(content: Dictionary, slice_name: String) -> Variant:
+	if not content.has("meta") or not content.meta.has("slices"):
+		return null
+	for slice in content.meta.slices:
+		if slice.name == slice_name:
+			if slice.keys.size() > 0:
+				var p = slice.keys[0].bounds
+				return Rect2(p.x, p.y, p.w, p.h)
+	return null
 
 
 ##

--- a/addons/AsepriteWizard/aseprite/file_exporter.gd
+++ b/addons/AsepriteWizard/aseprite/file_exporter.gd
@@ -60,7 +60,6 @@ func generate_aseprite_files(source_file: String, options: Dictionary):
 ##    only_visible_layers (boolean, optional)
 ##
 ## Return:
-##  Array
 ##    Dictionary
 ##     sprite_sheet: sprite sheet path
 ##     data_file:  json file path

--- a/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
@@ -4,22 +4,31 @@ func _get_meta_prop_names():
 	return [ "visible" ]
 
 
-func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
+func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary, is_importing_slice: bool):
 	var texture = _load_texture(sprite_sheet)
 	sprite.texture = texture
 
 	if content.frames.is_empty():
 		return
 
-	sprite.hframes = content.meta.size.w / content.frames[0].sourceSize.w
-	sprite.vframes = content.meta.size.h / content.frames[0].sourceSize.h
+	if is_importing_slice:
+		sprite.region_enabled = true
+		sprite.hframes = 1
+		sprite.vframes = 1
+		sprite.frame = 0
+	else:
+		sprite.region_enabled = false
+		sprite.hframes = content.meta.size.w / content.frames[0].sourceSize.w
+		sprite.vframes = content.meta.size.h / content.frames[0].sourceSize.h
 
 
-func _get_frame_property() -> String:
-	return "frame"
+func _get_frame_property(is_importing_slice: bool) -> String:
+	return "frame" if not is_importing_slice else "region_rect"
 
 
-func _get_frame_key(sprite:  Node, frame: Dictionary, context: Dictionary):
+func _get_frame_key(sprite:  Node, frame: Dictionary, context: Dictionary, slice_info: Variant):
+	if slice_info != null:
+		return _create_slice_rect(frame, slice_info)
 	return _calculate_frame_index(sprite,frame)
 
 
@@ -28,3 +37,12 @@ func _calculate_frame_index(sprite: Node, frame: Dictionary) -> int:
 	var row = floor(frame.frame.y * sprite.vframes / sprite.texture.get_height())
 	return (row * sprite.hframes) + column
 
+
+func _create_slice_rect(frame_data: Dictionary, slice_rect: Rect2) -> Rect2:
+	var frame = frame_data.frame
+	return Rect2(
+		frame.x + slice_rect.position.x,
+		frame.y + slice_rect.position.y,
+		slice_rect.size.x,
+		slice_rect.size.y
+	)

--- a/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
@@ -5,21 +5,28 @@ func _get_meta_prop_names():
 	return [ "visible" ]
 
 
-func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary):
+func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary, _is_importing_slice: bool):
 	context["base_texture"] = _load_texture(sprite_sheet)
 
 
-func _get_frame_property() -> String:
+func _get_frame_property(_is_importing_slice: bool) -> String:
 	return "texture"
 
 
-func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary):
-	return _get_atlas_texture(context["base_texture"], frame)
+func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary, slice_info: Variant):
+	return _get_atlas_texture(context["base_texture"], frame, slice_info)
 
 
-func _get_atlas_texture(base_texture: Texture2D, frame_data: Dictionary) -> AtlasTexture:
+func _get_atlas_texture(base_texture: Texture2D, frame_data: Dictionary, slice_info: Variant) -> AtlasTexture:
 	var tex = AtlasTexture.new()
 	tex.atlas = base_texture
 	tex.region = Rect2(Vector2(frame_data.frame.x, frame_data.frame.y), Vector2(frame_data.frame.w, frame_data.frame.h))
 	tex.filter_clip = true
+
+	if slice_info != null:
+		tex.region.position.x += slice_info.position.x
+		tex.region.position.y += slice_info.position.y
+		tex.region.size.x = slice_info.size.x
+		tex.region.size.y = slice_info.size.y
+
 	return tex

--- a/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
+++ b/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
@@ -1,0 +1,26 @@
+@tool
+extends "../base_sprite_resource_creator.gd"
+
+func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictionary) -> void:
+	var source_file = aseprite_files.data_file
+	var sprite_sheet = aseprite_files.sprite_sheet
+	var data = _aseprite_file_exporter.load_json_content(source_file)
+	var texture = ResourceLoader.load(sprite_sheet)
+
+	if not data.is_ok:
+		printerr("Failed to load aseprite source %s" % source_file)
+		return
+
+	if options.slice == "":
+		target_node.texture = texture
+	else:
+		var region = _aseprite.get_slice_rect(data.content, options.slice)
+		var atlas_texture := AtlasTexture.new()
+		atlas_texture.atlas = texture
+		atlas_texture.region = region
+		target_node.texture = atlas_texture
+
+	if target_node is CanvasItem:
+		target_node.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	else:
+		target_node.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
@@ -13,6 +13,7 @@ var config
 var file_system: EditorFileSystem
 
 var _layer: String = ""
+var _slice: String = ""
 var _source: String = ""
 var _file_dialog_aseprite: EditorFileDialog
 var _output_folder_dialog: EditorFileDialog
@@ -24,6 +25,7 @@ var _layer_default := "[all]"
 
 @onready var _source_field = $margin/VBoxContainer/source/button
 @onready var _layer_field = $margin/VBoxContainer/layer/options
+@onready var _slice_field = $margin/VBoxContainer/slice/options
 @onready var _options_title = $margin/VBoxContainer/options_title/options_title
 @onready var _options_container = $margin/VBoxContainer/options
 @onready var _out_folder_field = $margin/VBoxContainer/options/out_folder/button
@@ -50,6 +52,10 @@ func _load_config(cfg):
 	if cfg.get("layer", "") != "":
 		_layer_field.clear()
 		_set_layer(cfg.layer)
+
+	if cfg.get("slice", "") != "":
+		_slice_field.clear()
+		_set_slice(cfg.slice)
 
 	_set_out_folder(cfg.get("o_folder", ""))
 	_out_filename_field.text = cfg.get("o_name", "")
@@ -78,7 +84,7 @@ func _set_layer(layer):
 
 func _on_layer_button_down():
 	if _source == "":
-		_show_message("Please. Select source file first.")
+		_show_message("Please, select source file first.")
 		return
 
 	var layers = sprite_frames_creator.list_layers(ProjectSettings.globalize_path(_source))
@@ -104,6 +110,39 @@ func _on_layer_item_selected(index):
 	_save_config()
 
 
+func _set_slice(slice):
+	_slice = slice
+	_slice_field.add_item(_slice)
+
+
+func _on_slice_item_selected(index):
+	if index == 0:
+		_slice = ""
+		return
+	_slice = _slice_field.get_item_text(index)
+	_save_config()
+
+
+func _on_slice_button_down():
+	if _source == "":
+		_show_message("Please, select source file first.")
+		return
+
+	var slices = sprite_frames_creator.list_slices(ProjectSettings.globalize_path(_source))
+	var current = 0
+	_slice_field.clear()
+	_slice_field.add_item(_layer_default)
+
+	for s in slices:
+		if s == "":
+			continue
+
+		_slice_field.add_item(s)
+		if s == _slice:
+			current = _slice_field.get_item_count() - 1
+	_slice_field.select(current)
+
+
 func _on_source_pressed():
 	_open_source_dialog()
 
@@ -126,7 +165,7 @@ func _on_import_pressed():
 		"exception_pattern": _ex_pattern_field.text,
 		"only_visible_layers": _visible_layers_field.button_pressed,
 		"output_filename": _out_filename_field.text,
-		"layer": _layer
+		"layer": _layer,
 	}
 
 	_save_config()
@@ -142,7 +181,7 @@ func _on_import_pressed():
 	file_system.scan()
 	await file_system.filesystem_changed
 
-	sprite_frames_creator.create_animations(sprite, aseprite_output.content)
+	sprite_frames_creator.create_animations(sprite, aseprite_output.content, { "slice": _slice })
 	_importing = false
 
 	if config.should_remove_source_files():
@@ -154,6 +193,7 @@ func _save_config():
 	wizard_config.save_config(sprite, config.is_use_metadata_enabled(), {
 		"source": _source,
 		"layer": _layer,
+		"slice": _slice,
 		"op_exp": _options_title.button_pressed,
 		"o_folder": _output_folder,
 		"o_name": _out_filename_field.text,

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.tscn
@@ -59,7 +59,7 @@ popup/item_0/id = 0
 
 [node name="slice" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
-tooltip_text = "Aseprite layer to be used in the animation. By default all layers are included."
+tooltip_text = "Aseprite slice to be used in the animation. By default, the whole file is included."
 
 [node name="Label" type="Label" parent="margin/VBoxContainer/slice"]
 layout_mode = 2

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.tscn
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.tscn
@@ -57,6 +57,25 @@ selected = 0
 popup/item_0/text = "[all]"
 popup/item_0/id = 0
 
+[node name="slice" type="HBoxContainer" parent="margin/VBoxContainer"]
+layout_mode = 2
+tooltip_text = "Aseprite layer to be used in the animation. By default all layers are included."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/slice"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Slice"
+
+[node name="options" type="OptionButton" parent="margin/VBoxContainer/slice"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+item_count = 1
+selected = 0
+popup/item_0/text = "[all]"
+popup/item_0/id = 0
+
 [node name="options_title" type="PanelContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
 
@@ -135,6 +154,8 @@ text = "Import"
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
 [connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
+[connection signal="button_down" from="margin/VBoxContainer/slice/options" to="." method="_on_slice_button_down"]
+[connection signal="item_selected" from="margin/VBoxContainer/slice/options" to="." method="_on_slice_item_selected"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
 [connection signal="dir_dropped" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_dir_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]

--- a/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
@@ -93,6 +93,25 @@ selected = 0
 popup/item_0/text = "[all]"
 popup/item_0/id = 0
 
+[node name="slice" type="HBoxContainer" parent="margin/VBoxContainer"]
+layout_mode = 2
+tooltip_text = "Aseprite layer to be used in the animation. By default all layers are included."
+
+[node name="Label" type="Label" parent="margin/VBoxContainer/slice"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Slice"
+
+[node name="options" type="OptionButton" parent="margin/VBoxContainer/slice"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+item_count = 1
+selected = 0
+popup/item_0/text = "[all]"
+popup/item_0/id = 0
+
 [node name="options_title" type="PanelContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
 
@@ -205,6 +224,8 @@ text = "Import"
 [connection signal="pressed" from="margin/VBoxContainer/source/button" to="." method="_on_source_pressed"]
 [connection signal="button_down" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_button_down"]
 [connection signal="item_selected" from="margin/VBoxContainer/layer/options" to="." method="_on_layer_item_selected"]
+[connection signal="button_down" from="margin/VBoxContainer/slice/options" to="." method="_on_slice_button_down"]
+[connection signal="item_selected" from="margin/VBoxContainer/slice/options" to="." method="_on_slice_item_selected"]
 [connection signal="toggled" from="margin/VBoxContainer/options_title/options_title" to="." method="_on_options_title_toggled"]
 [connection signal="dir_dropped" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_dir_dropped"]
 [connection signal="pressed" from="margin/VBoxContainer/options/out_folder/button" to="." method="_on_out_folder_pressed"]

--- a/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
+++ b/addons/AsepriteWizard/interface/docks/sprite/animation_player_inspector_dock.tscn
@@ -95,7 +95,7 @@ popup/item_0/id = 0
 
 [node name="slice" type="HBoxContainer" parent="margin/VBoxContainer"]
 layout_mode = 2
-tooltip_text = "Aseprite layer to be used in the animation. By default all layers are included."
+tooltip_text = "Aseprite slice to be used in the animation. By default, the whole file is included."
 
 [node name="Label" type="Label" parent="margin/VBoxContainer/slice"]
 layout_mode = 2

--- a/addons/AsepriteWizard/interface/docks/wizard/as_wizard_window.gd
+++ b/addons/AsepriteWizard/interface/docks/wizard/as_wizard_window.gd
@@ -131,7 +131,7 @@ func _on_next_btn_up():
 	await _file_system.filesystem_changed
 
 	var exit_code = OK
-	
+
 	if !options.get("do_not_create_resource", false):
 		exit_code = _sf_creator.create_and_save_resources(aseprite_output.content)
 

--- a/project.godot
+++ b/project.godot
@@ -17,6 +17,7 @@ config/icon="res://icon.png"
 [aseprite]
 
 animation/layers/exclusion_pattern="_$"
+import/cleanup/remove_json_file=false
 
 [editor_plugins]
 

--- a/project.godot
+++ b/project.godot
@@ -17,7 +17,6 @@ config/icon="res://icon.png"
 [aseprite]
 
 animation/layers/exclusion_pattern="_$"
-import/cleanup/remove_json_file=false
 
 [editor_plugins]
 


### PR DESCRIPTION
Allows importing specific regions from Aseprite by setting slices and selecting it via dock.

![Screenshot from 2024-02-12 19-29-00](https://github.com/viniciusgerevini/godot-aseprite-wizard/assets/4930052/d84a5d4c-f283-401c-aa09-2f58fd48006f)

Related #119 