### PR TITLE
fix crash when exiting Godot on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Aseprite Wizard menus are now grouped under `Project -> Tools -> Aseprite Wizard`.
 
+### Fixed
+
+- Fixed crash on quitting Godot in MacOS.
+
+### Thanks
+
+- Thanks @sandord for fixing outdated PATH instruction message.
+- Thanks @tanuki-billie for reporting the MacOS exit crash.
+
 ## 7.3.0 (2024-02-13)
 
 ### Added

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -47,6 +47,10 @@ func _enter_tree():
 	_setup_sprite_inspector_plugin()
 
 
+func _exit_tree():
+	_disable_plugin()
+
+
 func _disable_plugin():
 	_remove_menu_entries()
 	_remove_importer()


### PR DESCRIPTION
#137 

It seems Godot on MacOS hangs if the plugin is not teared down.