### PR TITLE
Fix config cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 7.4.1 (2024-05-12)
+
+### Fixed
+
+- Project settins were being removed on exit. Now settings won´t be removed even when plugin is disabled.
+
+### Thanks
+
+- Thanks @sandord for finding and reporting the config issue
+
 ## 7.4.0 (2024-04-23)
 
 ### Added

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -57,7 +57,6 @@ func _disable_plugin():
 	_remove_exporter()
 	_remove_wizard_dock()
 	_remove_inspector_plugins()
-	config.clear_project_settings()
 
 
 func _load_config():


### PR DESCRIPTION
Project settings were being removed on exit. Settings were being removed when plugin was disabled, but I realized that is probably an annoyance. Now settings won't be removed even when plugin is disabled.

Fix #147 