### PR TITLE
Bugfix: res:/ was being set as default output instead of res://

### DIFF
--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -76,7 +76,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
 
-	var source_path = source_file.substr(0, source_file.rfind('/'))
+	var source_path = source_file.substr(0, source_file.rfind('/')+1)
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -76,7 +76,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
 
-	var source_path = source_file.substr(0, source_file.rfind('/')+1)
+	var source_path = source_file.get_base_dir()
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -63,7 +63,7 @@ func _get_option_visibility(path, option, options):
 func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
-	var source_path = source_file.substr(0, source_file.rfind('/'))
+	var source_path = source_file.substr(0, source_file.rfind('/')+1)
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -63,7 +63,7 @@ func _get_option_visibility(path, option, options):
 func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
-	var source_path = source_file.substr(0, source_file.rfind('/')+1)
+	var source_path = source_file.get_base_dir()
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -63,7 +63,7 @@ func _get_option_visibility(path, option, options):
 func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
-	var source_path = source_file.substr(0, source_file.rfind('/'))
+	var source_path = source_file.substr(0, source_file.rfind('/')+1)
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -63,7 +63,7 @@ func _get_option_visibility(path, option, options):
 func _import(source_file, save_path, options, platform_variants, gen_files):
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
-	var source_path = source_file.substr(0, source_file.rfind('/')+1)
+	var source_path = source_file.get_base_dir()
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 


### PR DESCRIPTION
Working on a new video I was trying to export via reimport button on the import tab and got the error:

 Error importing 'res://bluesquare.aseprite'.
 ERROR - Could not import aseprite file: output location does not exist
<br/>
![Screenshot 2024-06-02 153830](https://github.com/viniciusgerevini/godot-aseprite-wizard/assets/1005054/5b7f6deb-d782-4444-a08b-c469dfa9fdce)
<br/>
When investigating I found the folder dir was being set to res:/ instead of res:// causing export failures. see screenshot below of the discovery.
<br/>
![Screenshot 2024-06-02 154114](https://github.com/viniciusgerevini/godot-aseprite-wizard/assets/1005054/aeae78be-36f8-46d6-bfa8-490f812bda83)

This fix adds the +1 to finding the '/' on the directory so 'res://' is the output on the 3 options.
