### PR TITLE
Set different default command depending on OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- Operational system specific default command.
+
 ### Fixed
 
 - Automatic import would not work when aseprite file was in the root directory. (@HexBlit)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Aseprite Wizard is only required during development. If you decide to not use it
 
 Follow Godot [ installing plugins guide ]( https://docs.godotengine.org/en/stable/tutorials/plugins/editor/installing_plugins.html).
 
-If you are using Windows, a portable version or if the `aseprite` command is not in your PATH, you need to set the right path on `Editor -> Editor Settings -> Aseprite`.
+After installing the plugin, you need to make sure it's using the right Aseprite command. You can test the command by going to `Project > Tools > Aseprite Wizard > Config...`. If you get "command not found" instead of aseprite's version, you need to change the path to the Aseprite executable.
+
+You can also change the path via editor settings: `Editor -> Editor Settings -> Aseprite`.
 
 | Configuration           | Description |
 | ----------------------- | ----------- |

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -52,7 +52,13 @@ var _editor_settings: EditorSettings = EditorInterface.get_editor_settings()
 ######################################################
 
 func default_command() -> String:
-	return 'aseprite'
+	match OS.get_name():
+		"Windows":
+			return "C:\\\\Steam\\steamapps\\common\\Aseprite\\aseprite.exe"
+		"macOS":
+			return "/Applications/Aseprite.app/Contents/MacOS/aseprite"
+		_:
+			return 'aseprite'
 
 
 func is_command_or_control_pressed() -> String:


### PR DESCRIPTION
This might prevent some confusion as many people tend to set the path on macOS wrong due to how the system shows apps in the finder.