### PR TITLE
Fix bulk import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+
+### Fixed
+
+- Editor would crash when re-importing a big number of files. Threading texture load and debouncing scans to fix it.
+
+
+### Thanks
+
+- Thanks @0Volcanon, @KeyboardDanni and @thyancey for reporting and helping debug the re-import crash issue.
+
 ## 7.5.0 (2024-05-28)
 
 ### Added

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -173,7 +173,8 @@ func _get_min_duration(frames) -> int:
 
 
 func _load_texture(path) -> CompressedTexture2D:
-	return ResourceLoader.load(path, "CompressedTexture2D", ResourceLoader.CACHE_MODE_REPLACE)
+	ResourceLoader.load_threaded_request(path, "CompressedTexture2D", false, ResourceLoader.CACHE_MODE_REPLACE)
+	return ResourceLoader.load_threaded_get(path)
 
 
 func _add_to_sprite_frames(

--- a/addons/AsepriteWizard/importers/file_system_helper.gd
+++ b/addons/AsepriteWizard/importers/file_system_helper.gd
@@ -1,0 +1,22 @@
+@tool
+extends Node
+
+
+const WAIT_TIME_IN_SECONDS := 0.8
+var _time_left := 0.0
+var _scheduled := false
+
+## Schedule a file system scan. This method works like a debouncer
+## postponing the scan until no more calls are being made
+func schedule_file_system_scan() -> void:
+	_time_left = WAIT_TIME_IN_SECONDS
+	_scheduled = true
+
+
+func _process(delta: float) -> void:
+	if _scheduled:
+		if _time_left > 0.0:
+			_time_left -= delta
+		else:
+			_scheduled = false
+			EditorInterface.get_resource_filesystem().scan.call_deferred()

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -8,6 +8,12 @@ var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
 
+var file_system_helper
+
+func _init(fs_helper) -> void:
+	file_system_helper = fs_helper
+
+
 func _get_importer_name():
 	# ideally this should be called aseprite_wizard.plugin.spriteframes
 	# but I'm keeping it like this to avoid unnecessary breaking changes
@@ -97,12 +103,12 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		return FAILED
 
 
-	var should_trigger_scan = false
-
 	for sf in source_files.content:
 		if sf.is_first_import:
 			file_system.update_file(sf.sprite_sheet)
 			append_import_external_resource(sf.sprite_sheet)
+		else:
+			file_system_helper.schedule_file_system_scan()
 
 	var resources = _sf_creator.create_resources(source_files.content)
 
@@ -141,3 +147,5 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 func _remove_source_files(source_files: Array):
 	for s in source_files:
 		DirAccess.remove_absolute(s.data_file)
+		file_system_helper.schedule_file_system_scan()
+

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -103,11 +103,6 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		if sf.is_first_import:
 			file_system.update_file(sf.sprite_sheet)
 			append_import_external_resource(sf.sprite_sheet)
-		else:
-			should_trigger_scan = true
-
-	if should_trigger_scan:
-		file_system.scan()
 
 	var resources = _sf_creator.create_resources(source_files.content)
 
@@ -146,5 +141,3 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 func _remove_source_files(source_files: Array):
 	for s in source_files:
 		DirAccess.remove_absolute(s.data_file)
-
-	file_system.call_deferred("scan")

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -84,13 +84,12 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	if ResourceLoader.exists(sprite_sheet):
-		file_system.scan()
-	else:
+	if not ResourceLoader.exists(sprite_sheet):
 		file_system.update_file(sprite_sheet)
 		append_import_external_resource(sprite_sheet)
 
-	var texture: CompressedTexture2D = ResourceLoader.load(sprite_sheet, "CompressedTexture2D", ResourceLoader.CACHE_MODE_REPLACE)
+	ResourceLoader.load_threaded_request(sprite_sheet, "CompressedTexture2D", false, ResourceLoader.CACHE_MODE_REPLACE)
+	var texture: CompressedTexture2D = ResourceLoader.load_threaded_get(sprite_sheet)
 
 	return _save_resource(texture, save_path, result.content.data_file, data.meta.size)
 
@@ -128,7 +127,6 @@ func _save_resource(texture: CompressedTexture2D, save_path: String, data_file_p
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
-		file_system.call_deferred("scan")
 
 	if exit_code != OK:
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -11,6 +11,10 @@ var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 
 var config = preload("../config/config.gd").new()
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
+var file_system_helper
+
+func _init(fs_helper) -> void:
+	file_system_helper = fs_helper
 
 
 func _get_importer_name():
@@ -84,7 +88,9 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	if not ResourceLoader.exists(sprite_sheet):
+	if ResourceLoader.exists(sprite_sheet):
+		file_system_helper.schedule_file_system_scan()
+	else:
 		file_system.update_file(sprite_sheet)
 		append_import_external_resource(sprite_sheet)
 
@@ -127,6 +133,7 @@ func _save_resource(texture: CompressedTexture2D, save_path: String, data_file_p
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
+		file_system_helper.schedule_file_system_scan()
 
 	if exit_code != OK:
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -11,7 +11,10 @@ var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 
 var config = preload("../config/config.gd").new()
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
+var file_system_helper
 
+func _init(fs_helper) -> void:
+	file_system_helper = fs_helper
 
 func _get_importer_name():
 	return "aseprite_wizard.plugin.tileset-texture"
@@ -83,7 +86,9 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	if not ResourceLoader.exists(sprite_sheet):
+	if ResourceLoader.exists(sprite_sheet):
+		file_system_helper.schedule_file_system_scan()
+	else:
 		file_system.update_file(sprite_sheet)
 		append_import_external_resource(sprite_sheet)
 
@@ -126,6 +131,7 @@ func _save_resource(texture: CompressedTexture2D, save_path: String, data_file_p
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
+		file_system_helper.schedule_file_system_scan()
 
 	if exit_code != OK:
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -83,13 +83,12 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	if ResourceLoader.exists(sprite_sheet):
-		file_system.scan()
-	else:
+	if not ResourceLoader.exists(sprite_sheet):
 		file_system.update_file(sprite_sheet)
 		append_import_external_resource(sprite_sheet)
 
-	var texture: CompressedTexture2D = ResourceLoader.load(sprite_sheet, "CompressedTexture2D", ResourceLoader.CACHE_MODE_REPLACE)
+	ResourceLoader.load_threaded_request(sprite_sheet, "CompressedTexture2D", false, ResourceLoader.CACHE_MODE_REPLACE)
+	var texture: CompressedTexture2D = ResourceLoader.load_threaded_get(sprite_sheet)
 
 	return _save_resource(texture, save_path, result.content.data_file, data.meta.size)
 
@@ -127,7 +126,6 @@ func _save_resource(texture: CompressedTexture2D, save_path: String, data_file_p
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
-		file_system.call_deferred("scan")
 
 	if exit_code != OK:
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -6,6 +6,7 @@ const NoopImportPlugin = preload("importers/noop_import_plugin.gd")
 const SpriteFramesImportPlugin = preload("importers/sprite_frames_import_plugin.gd")
 const TilesetTextureImportPlugin = preload("importers/tileset_texture_import_plugin.gd")
 const TextureImportPlugin = preload("importers/static_texture_import_plugin.gd")
+const FileSystemHelper = preload("importers/file_system_helper.gd")
 
 # export
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
@@ -31,6 +32,8 @@ var imports_list_panel: MarginContainer
 var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
+
+var file_system_helper
 
 var _exporter_enabled = false
 
@@ -77,11 +80,13 @@ func _remove_menu_entries():
 
 
 func _setup_importer():
+	file_system_helper = FileSystemHelper.new()
+	add_child(file_system_helper)
 	_importers = [
 		NoopImportPlugin.new(),
-		SpriteFramesImportPlugin.new(),
-		TilesetTextureImportPlugin.new(),
-		TextureImportPlugin.new(),
+		SpriteFramesImportPlugin.new(file_system_helper),
+		TilesetTextureImportPlugin.new(file_system_helper),
+		TextureImportPlugin.new(file_system_helper),
 	]
 
 	for i in _importers:
@@ -91,6 +96,10 @@ func _setup_importer():
 func _remove_importer():
 	for i in _importers:
 		remove_import_plugin(i)
+
+	if file_system_helper != null:
+		file_system_helper.queue_free()
+		file_system_helper = null
 
 
 func _setup_exporter():


### PR DESCRIPTION
As reported on #157 , when re-importing multiple files at same time the plugin would crash Godot. That was worse when running a clean repo clone as the editor would crash multiple times until enough files were imported.

To fix this: 
- Loading textures using `ResourceLoader.load_threaded_request` to offload processing from the main thread
- Implemented scan debouncing to only trigger scan once all imports are finished

Tested sprite sheets, texture and tileset importers.

- [x] Linux test
- [x] MacOS test
- [x] Windows test

Test updates:

I tested importing 1000 SpriteFrame files at once.

- Linux:
No issues during my tests. It was reported on #157 that some projects still show some warnings on the first time a project is imported, but it does not seem to impact the import.

- MacOS:
    - Crashed 3 times and showed some thread errors, but imports were successful.
    - I run the tests in a 2018 Intel Macbook Pro, which to be honest is super slow and probably contributed to the issues. Not saying a faster machine wouldn't crash, but if this is the only problem I will go ahead and merge my changes.
    - Running tests with a couple of hundreds of file crashed only once, without any warnings. Files were imported successfully.

- Windows
No issues in my tests, besides import being kinda slow compared to Linux. There is another issue reported on #157 that seems to triggered multiple re-imports for a single file. It doesn't happen on my machines and it might be a different error.