### PR TITLE
Add tileset sheet type configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- Added sheet type and number of columns options to tileset texture importer.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Tileset importer options:
 | ----------------------- | ----------- |
 | Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+| Sheet type | Algorithm to create spritesheet. Options: packed, horizontal, vertical, columns. Default: columns|
+| Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.
+
 
 __Note:__ Like in the static image importer, a png file is generated alongside the resource. I noticed that sometimes when updating the aseprite file, Godot is keeping a cached version of the resource and not showing the update in the tileset editor. The same doesn't happen to the png file, so you might want to use it instead of the main .aseprite file.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Tileset importer options:
 | ----------------------- | ----------- |
 | Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
-| Sheet type | Algorithm to create spritesheet. Options: packed, horizontal, vertical, columns. Default: columns|
+| Sheet type | Algorithm to create spritesheet. Options: columns, horizontal, vertical, packed. Default: columns|
 | Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.
 
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -104,7 +104,29 @@ func _add_ignore_layer_arguments(file_name: String, arguments: Array, exception_
 			arguments.push_front(l)
 			arguments.push_front('--ignore-layer')
 
+
 func _add_sheet_type_arguments(arguments: Array, options : Dictionary):
+	if options.has("column_count"):
+		_old_sheet_type_config(arguments, options)
+		return
+
+	var sheet_type = options.get("sheet_type", "packed")
+	var item_count = options.get("sheet_columns", 0)
+
+	if (sheet_type == "columns" or sheet_type == "rows") and item_count == 0:
+		sheet_type = "packed"
+	elif options.get("sheet_merge_duplicates", true):
+		arguments.push_back("--merge-duplicates")
+
+	if sheet_type == "columns":
+		arguments.push_back("--sheet-columns")
+		arguments.push_back(item_count)
+	else:
+		arguments.push_back("--sheet-type")
+		arguments.push_back(sheet_type)
+
+
+func _old_sheet_type_config(arguments: Array, options : Dictionary):
 	var column_count : int = options.get("column_count", 0)
 	if column_count > 0:
 		arguments.push_back("--merge-duplicates") # Yes, this is undocumented
@@ -265,6 +287,8 @@ func export_tileset_texture(file_name: String, output_folder: String, options: D
 
 	if not only_visible_layers:
 		arguments.push_front("--all-layers")
+
+	_add_sheet_type_arguments(arguments, options)
 
 	_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
 

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -56,8 +56,17 @@ func _get_import_options(_path, _i):
 	return [
 		{"name": "exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
 		{"name": "only_visible_layers",    "default_value": false},
+		{
+			"name": "sheet/sheet_type",
+			"default_value": "packed",
+			"property_hint": PROPERTY_HINT_ENUM,
+			"hint_string": "packed,horizontal,vertical,columns",
+		},
+		{
+			"name": "sheet/sheet_columns",
+			"default_value": 0,
+		},
 	]
-
 
 func _get_option_visibility(path, option, options):
 	return true
@@ -75,6 +84,8 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		"only_visible_layers": options['only_visible_layers'],
 		"output_filename": '',
 		"output_folder": source_path,
+		"sheet_type": options["sheet/sheet_type"],
+		"sheet_columns": options["sheet/sheet_columns"],
 	}
 
 	var result = _generate_texture(absolute_source_file, aseprite_opts)

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -58,13 +58,13 @@ func _get_import_options(_path, _i):
 		{"name": "only_visible_layers",    "default_value": false},
 		{
 			"name": "sheet/sheet_type",
-			"default_value": "packed",
+			"default_value": "columns",
 			"property_hint": PROPERTY_HINT_ENUM,
 			"hint_string": "packed,horizontal,vertical,columns",
 		},
 		{
 			"name": "sheet/sheet_columns",
-			"default_value": 0,
+			"default_value": 12,
 		},
 	]
 

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -60,7 +60,7 @@ func _get_import_options(_path, _i):
 			"name": "sheet/sheet_type",
 			"default_value": "columns",
 			"property_hint": PROPERTY_HINT_ENUM,
-			"hint_string": "packed,horizontal,vertical,columns",
+			"hint_string": "columns,horizontal,vertical,packed",
 		},
 		{
 			"name": "sheet/sheet_columns",


### PR DESCRIPTION
For most imports using the pack algorithm is a good option. However, for tilesets it's probably not useful to use it as tiles would could change position on new imports, messing with other tile configurations.

In this PR I'm adding the following config:

Sheet type:
- Horizontal: Exports tiles in a single line
- Vertical: Exports tiles in a single column
- Columns: Export tiles obeying the "Sheet columns"  options
- Packed: Regular pack algorithm. Not useful for tilesets but I'm keeping it as an option.

Sheet columns:
- Number of columns to use in the spritesheet when sheet type is column. This is the most useful one in my opinion as it allows people to decide their tileset arrangement.