### PR TITLE
Change "hide unused" option and fix track cleanup

### DIFF
--- a/addons/AsepriteWizard/config/wizard_config.gd
+++ b/addons/AsepriteWizard/config/wizard_config.gd
@@ -65,6 +65,10 @@ static func save_config(node: Object, cfg: Dictionary):
 	node.set_meta(WIZARD_CONFIG_META_NAME, cfg)
 
 
+static func has_config(node: Object) -> bool:
+	return node.has_meta(WIZARD_CONFIG_META_NAME)
+
+
 static func load_interface_config(node: Node, default: Dictionary = {}) -> Dictionary:
 	if node.has_meta(WIZARD_INTERFACE_CONFIG_META_NAME):
 		return node.get_meta(WIZARD_INTERFACE_CONFIG_META_NAME)

--- a/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/sprite_animation_creator.gd
@@ -1,8 +1,5 @@
 extends "animation_creator.gd"
 
-func _get_meta_prop_names():
-	return [ "visible" ]
-
 
 func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, context: Dictionary, is_importing_slice: bool):
 	var texture = _load_texture(sprite_sheet)
@@ -24,6 +21,11 @@ func _setup_texture(sprite: Node, sprite_sheet: String, content: Dictionary, con
 
 func _get_frame_property(is_importing_slice: bool) -> String:
 	return "frame" if not is_importing_slice else "region_rect"
+
+
+func _get_props_to_cleanup() -> Array[String]:
+	return ["frame", "region_rect", "visible"]
+
 
 
 func _get_frame_key(sprite:  Node, frame: Dictionary, context: Dictionary, slice_info: Variant):

--- a/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/texture_rect_animation_creator.gd
@@ -1,16 +1,16 @@
 extends "animation_creator.gd"
 
 
-func _get_meta_prop_names():
-	return [ "visible" ]
-
-
 func _setup_texture(target_node: Node, sprite_sheet: String, content: Dictionary, context: Dictionary, _is_importing_slice: bool):
 	context["base_texture"] = _load_texture(sprite_sheet)
 
 
 func _get_frame_property(_is_importing_slice: bool) -> String:
 	return "texture"
+
+
+func _get_props_to_cleanup() -> Array[String]:
+	return ["texture", "visible"]
 
 
 func _get_frame_key(target_node: Node, frame: Dictionary, context: Dictionary, slice_info: Variant):


### PR DESCRIPTION
Related to #158 

The "hide unused"  feature currently works on a weird way, and forces every node to have the "visible"  frame animated, which might be annoying if you need to hide your sprites programmatically.

In this PR I changed the "hide unused" behaviour and fixed animation/track cleanup that was broken.

Hide unused description: "If selected, sprites that are present in the AnimationPlayer will be set as visible=false in any animation they are not part of"

This is useful when you want to split your characters in multiple sprites or layers.

## The issue
This is how the feature is working at the moment. When importing an animation to an AnimationPlayer:
- Every sprite has the "visible"  property set to true
- When a sprite is imported with "Hide unused", it will set the "visible"  property of any sprite not included in the animation to false.

The issue with this approach is that it applies the visible flag to every sprite, even if they don't have the "hide unused"  feature enabled. Also, as mentioned before, it forces every sprite to have the visible flag set, which causes some other troubles.

## The change 
- With this fix, only set and control the visible property for sprites with "Hide unused" enabled.
- Sprites without the "Hide unused"  or not imported from Aseprite won't have the visible property animated.
- Fixed animation / track cleanup which was disabled as it stopped working after this feature was introduced. This cleanup removes any animation that has no tracks.

I'm still assessing if I should consider this a breaking change or not.
- [x] moar tests
