### PR TITLE
fix issue where animations with loop prefix were not included in final animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## 8.0.1 (2024-09-13)
+
+### Fixed
+
+- Animations using the loop prefix were not being imported.
+
+### Thanks
+
+Thanks @erniel for reporting the loop prefix issue.
+
 ## 8.0.0 (2024-09-12)
 
 ### Breaking changes

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -190,7 +190,7 @@ func _cleanup_animations(target_node: Node, player: AnimationPlayer, content: Di
 func _remove_unused_animations(target_node: Node, player: AnimationPlayer, content: Dictionary):
 	var tags: Array[String] = []
 	for t in content.meta.frameTags:
-		tags.push_back(t.name)
+		tags.push_back(_animation_name_without_loop_prefix(t.name))
 
 	for a in player.get_animation_list():
 		if tags.has(a):
@@ -325,3 +325,9 @@ func _relevant_track_count(target_node: Node, player: AnimationPlayer, animation
 			track_count += 1
 
 	return track_count
+
+
+func _animation_name_without_loop_prefix(animation_name: String) -> String:
+	if animation_name.begins_with(_config.get_animation_loop_exception_prefix()):
+		return animation_name.substr(_config.get_animation_loop_exception_prefix().length())
+	return animation_name

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Import Aseprite files to Godot in many different ways."
 author="Vinicius Gerevini"
-version="8.0.0"
+version="8.0.1"
 script="plugin.gd"


### PR DESCRIPTION
Reported on #164 

With the cleanup fix implemented on #162 , I forgot to consider animations with the loop prefix (i.e. `_animation`), so the final cleanup step was detecting those as stale and removing them.

This impacted AnimationPlayers only