### PR TITLE
Change Aseprite Texture importer type to be PortableCompressedTexture2D and not generate extra png

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ mono_crash.*.json
 
 # Project test files
 test/
+
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- Aseprite Texture importer does not generate a png file anymore, and has type `PortableCompressedTexture2D` instead of `AtlasTexture`.
+- Aseprite Texture importer does not generate a png file anymore, and has type `PortableCompressedTexture2D` instead of `AtlasTexture`. If you use the png file, you should change the references to the aseprite file instead.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+### Breaking changes
+
+- Aseprite Texture importer does not generate a png file anymore, and has type `PortableCompressedTexture2D` instead of `AtlasTexture`.
+
+### Changed
+
+- Aseprite Texture importer:
+    - Changed type to `PortableCompressedTexture2D`
+    - Does not generate extra png file anymore.
+
 ## 8.2.0 (2024-11-22)
 
 ### Added

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -34,7 +34,7 @@ func _get_save_extension():
 
 
 func _get_resource_type():
-	return "AtlasTexture"
+	return "PortableCompressedTexture2D"
 
 
 func _get_preset_count():
@@ -88,16 +88,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	if ResourceLoader.exists(sprite_sheet):
-		file_system_helper.schedule_file_system_scan()
-	else:
-		file_system.update_file(sprite_sheet)
-		append_import_external_resource(sprite_sheet)
-
-	ResourceLoader.load_threaded_request(sprite_sheet, "CompressedTexture2D", false, ResourceLoader.CACHE_MODE_REPLACE)
-	var texture: CompressedTexture2D = ResourceLoader.load_threaded_get(sprite_sheet)
-
-	return _save_resource(texture, save_path, result.content.data_file, data.meta.size)
+	return _save_resource(sprite_sheet, save_path, result.content.data_file, data.meta.size)
 
 
 func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dictionary:
@@ -107,7 +98,6 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 		return result
 
 	var sprite_sheet = result.content.sprite_sheet
-
 	var data_result = _aseprite_file_exporter.load_json_content(result.content.data_file)
 
 	if not data_result.is_ok:
@@ -122,20 +112,20 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 	})
 
 
-func _save_resource(texture: CompressedTexture2D, save_path: String, data_file_path: String, size: Dictionary) -> int:
-	var resource = AtlasTexture.new()
-	resource.atlas = texture
-	resource.region = Rect2(0, 0, size.w, size.h)
+func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
+	var image = Image.load_from_file(sprite_sheet)
 
-	var resource_path = "%s.res" % save_path
-	var exit_code = ResourceSaver.save(resource, resource_path)
-	resource.take_over_path(resource_path)
+	var tex := PortableCompressedTexture2D.new()
+	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+#
+	var exit_code = ResourceSaver.save(tex, "%s.%s" % [save_path, _get_save_extension()])
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
-		file_system_helper.schedule_file_system_scan()
+		DirAccess.remove_absolute(sprite_sheet)
 
 	if exit_code != OK:
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
 		return FAILED
+
 	return OK


### PR DESCRIPTION
Thanks for the suggestion from discussion https://github.com/godotengine/godot-proposals/discussions/11042, now we don't need to keep the generated png file around anymore.

I'm validating the solution by changing the Aseprite Texture importer, which generates a static image.

- The Imported type will be a `PortableCompressedTexture2D`, instead of `AtlasTexture`. The `AtlasTexture` was a workaround to link to the spritesheet PNG, but not required anymore. This will save some extra bytes, but it shouldn't be a breaking change as both are textures.
- **(breaking change)** The spritesheet PNG is not exposed anymore. It's persisted inside the `.godot` folder as a compressed texture instead. if you are using this png directly, you should change the references to point to the aseprite file instead.

-----

I will implement this change in all the importers in follow up PRs. This new solution will help solve a few open issues:


- This PR solves this issue #174 , or rather prevents the scenario that triggers it.
- Once all importers are changed, this request can be closed #163.
- This also improves performance and likely fixes this issue for good #157, as I removed the extra file system scans.
- Once the sprite frames importer is changed, this will help to think on a way to prevent #152.
- Finally, this will allow me to finally implement #32 in a more elegant way.
