### PR TITLE
New "Multiple resource" importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Aseprite SpriteFrames importer does not generate extra png file anymore
 - Organised importer properties.
     - If you changed the default sheet options or layer options, they will be reverted to the default values on next import. Make sure to set them again before this happens
+- Renamed SpriteFrames importer id.
+
+### Added
+- New split importers (Static Texture, SpriteFrames). These importers should be used for exporting each layer in a Aseprite file as a separate resource. These resource are plain files that will hold the info to generate the file independently.
+    - This will prevent issues with unstable ids which happens when the import folder is removed and new files are generated. In these cases, even though the resulting files are the same, they have different interal references causing them to be shown as changed in version control.
+    - This will also allow cleanup to happen on split importers. i.e. when a layer is removed from the aseprite file, its resource will also be removed in Godot.
 
 ### Changed
 
@@ -20,6 +26,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     - Does not generate extra png file anymore.
 - Organised importer properties (layer related under layers section and implemented improved sheet options for SpriteFrames).
     - Any already existing import will revert to default values unless set correctly.
+- Renamed SpriteFrames importer id for consistency
+- Removed Split option from SpriteFrames importer. Split are handled in separate importers.
 
 ## 8.2.0 (2024-11-22)
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ After activating the plugin, there are three different ways you can use it:
 
 ### Importers
 
-If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project folder will be automatically imported as a resource. The plugin enables 3 importers: `SpriteFrames`, `Static Image` and `Tileset Texture`.
+If you use the importer flow, any `*.ase` or `*.aseprite` file saved in the project folder will be automatically imported as a resource. The plugin enables a few importers: `SpriteFrames`, `Static Image` and `Tileset Texture`.
 
 You can choose which importer to use via the Import Dock. By default, aseprite files will use the "No import" option, which will show them in the filesytem dock, but won´t generate any resource. You can change the default importer behaviour via Project Settings.
 
@@ -109,11 +109,23 @@ Options:
 
 | Field                   | Description |
 | ----------------------- | ----------- |
-| Output filename / prefix | Defines output filename. In case layers are split into multiple files, this is used as file prefix (e.g prefix_layer_name.res). If not set, the source filename is used.|
 | Exclude layers matching pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
-| Split layers in multiple resources: | If selected, each layer will be exported as a separated resource (e.g my_layer_1.res, layer_name_2.res, ...). If not selected, all layers will be merged and exported as a single resource file with the same base name as the source. |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+| Sheet type | Algorithm to create spritesheet. Options: columns, horizontal, vertical, packed. Default: Packed|
+| Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.
 | Animation / Round FPS | When selected, animation FPS is rounded to next integer. Default: true.|
+
+###### SpriteFrames split by layer
+
+You can generate one `SpriteFrames` resource for each layer by using the `SpriteFrames (Split by Layer)` importer. This importer will generate one `.ase_layer` file for each layer, which will be recognised as `SpriteFrames` and can be used directly. 
+
+This importer has the same properties as the regular `SpriteFrames` importer with one extra:
+
+| Field                   | Description |
+| ----------------------- | ----------- |
+| Layer Resources Folder | The folder where the layer resources should be created. Default: Same as source aseprite file|
+
+This importer will keep track of the generated resources and remove them if the layer is removed in Aseprite.
 
 #### Static image importer
 
@@ -125,6 +137,18 @@ Texture importer options:
 | ----------------------- | ----------- |
 | Exclude layers pattern: | Do not export layers that match the pattern defined. i.e `_draft$` excludes all layers ending with `_draft`. Uses Godot's [Regex implementation](https://docs.godotengine.org/en/stable/classes/class_regex.html)  |
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
+
+######  Static image split by layer
+
+You can generate one image resource for each layer by using the `Texture (Split by Layer)` importer. This importer will generate one `.ase_layer_tex` file for each layer, which will be recognised as `PortableCompressedTexture2D` and can be used directly. 
+
+This importer has the same properties as the regular `Texture` importer with one extra:
+
+| Field                   | Description |
+| ----------------------- | ----------- |
+| Layer Resources Folder | The folder where the layer resources should be created. Default: Same as source aseprite file|
+
+This importer will keep track of the generated resources and remove them if the layer is removed in Aseprite.
 
 #### Tileset texture importer
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -139,6 +139,19 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
 	return exception_layers
 
 
+func list_valid_layers(file_name: String, exception_pattern: String = "", show_only_visible: bool = false) -> Array:
+	var layers = list_layers(file_name, show_only_visible)
+	var exception_regex = _compile_regex(exception_pattern)
+
+	var output = []
+
+	for layer in layers:
+		if layer != "" and (not exception_regex or exception_regex.search(layer) == null):
+			output.push_back(layer)
+
+	return output
+
+
 func list_layers(file_name: String, only_visible = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layers", file_name]

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -23,6 +23,7 @@ const _IMPORTER_ENABLE_KEY = 'aseprite/import/import_plugin/enable_automatic_imp
 const _DEFAULT_IMPORTER_KEY = 'aseprite/import/import_plugin/default_automatic_importer'
 
 const IMPORTER_SPRITEFRAMES_NAME = "SpriteFrames"
+const IMPORTER_SPRITEFRAMES_SPLIT_NAME = "SpriteFrames (Split By Layer)"
 const IMPORTER_NOOP_NAME = "No Import"
 const IMPORTER_TILESET_TEXTURE_NAME = "Tileset Texture"
 const IMPORTER_STATIC_TEXTURE_NAME = "Static Texture"
@@ -151,7 +152,13 @@ func initialize_project_settings():
 		IMPORTER_SPRITEFRAMES_NAME if is_importer_enabled() else IMPORTER_NOOP_NAME,
 		TYPE_STRING,
 		PROPERTY_HINT_ENUM,
-		"%s,%s,%s,%s" % [IMPORTER_NOOP_NAME, IMPORTER_SPRITEFRAMES_NAME, IMPORTER_TILESET_TEXTURE_NAME, IMPORTER_STATIC_TEXTURE_NAME]
+		",".join([
+			IMPORTER_NOOP_NAME,
+			IMPORTER_SPRITEFRAMES_NAME,
+			IMPORTER_SPRITEFRAMES_SPLIT_NAME,
+			IMPORTER_TILESET_TEXTURE_NAME,
+			IMPORTER_STATIC_TEXTURE_NAME
+		])
 	)
 
 	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -27,6 +27,7 @@ const IMPORTER_SPRITEFRAMES_SPLIT_NAME = "SpriteFrames (Split By Layer)"
 const IMPORTER_NOOP_NAME = "No Import"
 const IMPORTER_TILESET_TEXTURE_NAME = "Tileset Texture"
 const IMPORTER_STATIC_TEXTURE_NAME = "Static Texture"
+const IMPORTER_STATIC_TEXTURE_SPLIT_NAME = "Static Texture (Split By Layer)"
 
 # wizard history
 const _WIZARD_HISTORY = "wizard_history"
@@ -157,7 +158,8 @@ func initialize_project_settings():
 			IMPORTER_SPRITEFRAMES_NAME,
 			IMPORTER_SPRITEFRAMES_SPLIT_NAME,
 			IMPORTER_TILESET_TEXTURE_NAME,
-			IMPORTER_STATIC_TEXTURE_NAME
+			IMPORTER_STATIC_TEXTURE_NAME,
+			IMPORTER_STATIC_TEXTURE_SPLIT_NAME
 		])
 	)
 

--- a/addons/AsepriteWizard/importers/helpers/file_system_helper.gd
+++ b/addons/AsepriteWizard/importers/helpers/file_system_helper.gd
@@ -1,0 +1,22 @@
+@tool
+extends Node
+
+const WAIT_TIME_IN_SECONDS := 0.8
+var _time_left := 0.0
+var _scheduled := false
+
+## Schedule a file system scan. This method works like a debouncer
+## postponing the scan until no more calls are being made
+func schedule_file_system_scan() -> void:
+	_time_left = WAIT_TIME_IN_SECONDS
+	_scheduled = true
+
+
+func _process(delta: float) -> void:
+	if _scheduled:
+		if _time_left > 0.0:
+			_time_left -= delta
+		else:
+			_scheduled = false
+			if not EditorInterface.get_resource_filesystem().is_scanning():
+				EditorInterface.get_resource_filesystem().scan.call_deferred()

--- a/addons/AsepriteWizard/importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/layer_import_plugin.gd
@@ -1,0 +1,110 @@
+@tool
+extends EditorImportPlugin
+
+const result_codes = preload("../config/result_codes.gd")
+
+var config = preload("../config/config.gd").new()
+var _aseprite = preload("../aseprite/aseprite.gd").new()
+var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
+
+
+func _get_importer_name():
+	return "aseprite_wizard.plugin.spriteframes-split-layer"
+
+
+func _get_visible_name():
+	return "Aseprite Layer SpriteFrames"
+
+
+func _get_recognized_extensions():
+	return ["ase_layer"]
+
+
+func _get_save_extension():
+	return "res"
+
+
+func _get_resource_type():
+	return "SpriteFrames"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_priority():
+	return 1.0
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_import_options(_path, _i):
+	return []
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _import(source_file, save_path, options, platform_variants, gen_files):
+	var file = FileAccess.open(source_file, FileAccess.READ)
+	var data = JSON.parse_string(file.get_as_text())
+
+	var source_path = source_file.get_base_dir()
+
+	var absolute_source_file = ProjectSettings.globalize_path(data.import_options.source)
+	
+	var export_options = {
+		"sheet_type": data.import_options.sheet_type,
+		"sheet_columns": data.import_options.sheet_columns,
+		"should_round_fps": data.import_options.should_round_fps,
+	}
+	
+	var source_files = _aseprite.export_file_with_layers(
+		absolute_source_file,
+		[data.layer],
+		source_path,
+		export_options,
+	)
+
+	if source_files.is_empty():
+		printerr("ERROR - Could not import aseprite file. Layer not found.")
+		return FAILED
+#
+	var resources = _sf_creator.create_resources([source_files], {
+		"should_round_fps": data.import_options.should_round_fps,
+		"should_create_portable_texture": true,
+		"sheet_base_path": save_path,
+	})
+
+	if not resources.is_ok:
+		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
+		return FAILED
+
+	var resource = resources.content[0]
+	var resource_path = "%s.res" % save_path
+	var exit_code = ResourceSaver.save(resource.resource, resource_path)
+	resource.resource.take_over_path(resource_path)
+
+	for extra_file in resource.extra_gen_files:
+		gen_files.push_back(extra_file)
+#
+	if config.should_remove_source_files():
+		_remove_source_files(source_files)
+
+	if exit_code != OK:
+		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		return FAILED
+
+	return OK
+
+
+func _remove_source_files(source_files: Dictionary):
+	DirAccess.remove_absolute(source_files.data_file)
+	DirAccess.remove_absolute(source_files.sprite_sheet)

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -1,0 +1,117 @@
+@tool
+extends EditorImportPlugin
+
+const result_codes = preload("../config/result_codes.gd")
+
+var config = preload("../config/config.gd").new()
+var _aseprite = preload("../aseprite/aseprite.gd").new()
+
+var file_system_helper
+
+func _init(fs_helper) -> void:
+	file_system_helper = fs_helper
+
+
+func _get_recognized_extensions():
+	return ["aseprite", "ase"]
+
+
+func _get_save_extension():
+	return "json"
+
+
+func _get_resource_type():
+	return "JSON"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _import(source_file, save_path, options, platform_variants, gen_files):
+	var old_data = _load_old_data(source_file)
+	var exception_pattern = options.get('layer/exclude_layers_pattern', "")
+	var should_include_only_visibles = options.get('layer/only_visible_layers', false)
+
+	var absolute_source_file = ProjectSettings.globalize_path(source_file)
+
+	var layers = _aseprite.list_valid_layers(
+		absolute_source_file,
+		exception_pattern,
+		should_include_only_visibles
+	)
+
+	var layers_resources_folder = options["output/layers_resources_folder"]
+
+	var import_options = _get_base_import_options(options)
+	import_options["source"] = source_file
+
+	var base_name = source_file.get_basename()
+	
+	if layers_resources_folder != "":
+		if not DirAccess.dir_exists_absolute(layers_resources_folder):
+			DirAccess.make_dir_recursive_absolute(layers_resources_folder)
+		base_name = "%s/%s" % [layers_resources_folder, base_name.get_file()]
+
+	var data_to_save = {
+		"layers": {}
+	}
+
+	for layer in layers:
+		var layer_save_path = "%s_l_%s.%s" % [base_name, layer, _layer_extension()]
+		var file = FileAccess.open(layer_save_path, FileAccess.WRITE)
+		file.store_string(JSON.stringify({
+			"layer": layer,
+			"import_options": import_options,
+		}))
+		data_to_save.layers[layer] = layer_save_path
+
+	var json = JSON.new()
+	json.data = data_to_save
+
+	var exit_code = ResourceSaver.save(json, "%s.%s" % [save_path, _get_save_extension()])
+
+	_cleanup_old_layers(old_data, layers)
+
+	file_system_helper.schedule_file_system_scan()
+
+	return exit_code
+
+
+func _layer_extension() -> String:
+	return ""
+
+func _get_base_import_options(options: Dictionary):
+	return {}
+
+
+func _load_old_data(source_file: String):
+	var old_data = {}
+
+	if ResourceLoader.exists(source_file):
+		var d = ResourceLoader.load(source_file)
+		if d is JSON:
+			old_data = d.data.layers
+
+	return old_data
+
+
+func _cleanup_old_layers(old_data: Dictionary, layers: Array):
+	var old_layers = old_data.keys()
+	for old_layer in old_layers:
+		if not layers.has(old_layer):
+			var file = old_data[old_layer]
+			if FileAccess.file_exists(file):
+				DirAccess.remove_absolute(file)

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -1,11 +1,11 @@
 @tool
 extends EditorImportPlugin
 
-const result_codes = preload("../config/result_codes.gd")
+const result_codes = preload("../../config/result_codes.gd")
 
-var config = preload("../config/config.gd").new()
-var _aseprite = preload("../aseprite/aseprite.gd").new()
-var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
+var config = preload("../../config/config.gd").new()
+var _aseprite = preload("../../aseprite/aseprite.gd").new()
+var _sf_creator = preload("../../creators/sprite_frames/sprite_frames_creator.gd").new()
 
 
 func _get_importer_name():

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
@@ -1,42 +1,40 @@
 @tool
-extends "./static_texture_import_plugin_base.gd"
-
+extends "../static_texture_import_plugin_base.gd"
 
 ##
-## Static texture importer.
-## Imports first frame from Aseprite file as texture
+## Static texture importer (Split).
+## Imports first frame from Aseprite file as texture in multiple resources
 ##
 
 func _get_importer_name():
-	return "aseprite_wizard.plugin.static-texture"
+	return "aseprite_wizard.plugin.static-texture-split-layer"
 
 
 func _get_visible_name():
-	return "Aseprite Texture"
+	return "Aseprite Layer Texture"
 
 
 func _get_recognized_extensions():
-	return ["aseprite", "ase"]
+	return ["ase_layer_tex"]
 
 
 func _get_priority():
-	return 2.0 if config.get_default_importer() == config.IMPORTER_STATIC_TEXTURE_NAME else 0.8
+	return 1.0
 
 
 func _get_import_options(_path, _i):
-	return [
-		{"name": "layer/exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
-		{"name": "layer/only_visible_layers",    "default_value": false},
-	]
+	return []
 
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
-	var absolute_source_file = ProjectSettings.globalize_path(source_file)
+	var file = FileAccess.open(source_file, FileAccess.READ)
+	var i_data = JSON.parse_string(file.get_as_text())
+
 	var source_path = source_file.get_base_dir()
+	var absolute_source_file = ProjectSettings.globalize_path(i_data.import_options.source)
 
 	var aseprite_opts = {
-		"exception_pattern": options['layer/exclude_layers_pattern'],
-		"only_visible_layers": options['layer/only_visible_layers'],
+		"layer": i_data.layer,
 		"output_filename": '',
 		"output_folder": source_path,
 		"first_frame_only": true,

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -10,9 +10,7 @@ var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
 
 
 func _get_importer_name():
-	# ideally this should be called aseprite_wizard.plugin.spriteframes
-	# but I'm keeping it like this to avoid unnecessary breaking changes
-	return "aseprite_wizard.plugin"
+	return "aseprite_wizard.plugin.spriteframes"
 
 
 func _get_visible_name():
@@ -49,7 +47,6 @@ func _get_import_order():
 
 func _get_import_options(_path, _i):
 	return [
-		{"name": "layer/split_layers",           "default_value": false},
 		{"name": "layer/exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
 		{"name": "layer/only_visible_layers",    "default_value": false},
 		{
@@ -78,13 +75,11 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var source_basename = source_file.substr(source_path.length()+1, -1)
 	source_basename = source_basename.substr(0, source_basename.rfind('.'))
 
-	var export_mode = _sf_creator.LAYERS_EXPORT_MODE if options['layer/split_layers'] else _sf_creator.FILE_EXPORT_MODE
-
 	var aseprite_opts = {
-		"export_mode": export_mode,
+		"export_mode": _sf_creator.FILE_EXPORT_MODE,
 		"exception_pattern": options['layer/exclude_layers_pattern'],
 		"only_visible_layers": options['layer/only_visible_layers'],
-		"output_filename": '' if export_mode == _sf_creator.FILE_EXPORT_MODE else '%s_' % source_basename,
+		"output_filename": '',
 		"output_folder": source_path,
 		"sheet_type": options["sheet/sheet_type"],
 		"sheet_columns": options["sheet/sheet_columns"],
@@ -104,22 +99,6 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	if not resources.is_ok:
 		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
 		return FAILED
-
-	if export_mode == _sf_creator.LAYERS_EXPORT_MODE:
-		# each layer is saved as one resource using base file name to prevent collisions
-		# the first layer will be saved in the default resource path to prevent
-		# godot from keeping re-importing it
-		for resource in resources.content:
-			var resource_path = "%s.res" % resource.data_file.get_basename();
-			var exit_code = ResourceSaver.save(resource.resource, resource_path)
-			resource.resource.take_over_path(resource_path)
-
-			if exit_code != OK:
-				printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
-				return FAILED
-
-			for extra_file in resource.extra_gen_files:
-				gen_files.push_back(extra_file)
 
 	var resource = resources.content[0]
 	var resource_path = "%s.res" % save_path

--- a/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
@@ -1,21 +1,5 @@
 @tool
-extends EditorImportPlugin
-
-const result_codes = preload("../config/result_codes.gd")
-
-var config = preload("../config/config.gd").new()
-#var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
-var _aseprite = preload("../aseprite/aseprite.gd").new()
-#var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
-#var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
-
-
-# TODO remove split option from main importer
-
-var file_system_helper
-
-func _init(fs_helper) -> void:
-	file_system_helper = fs_helper
+extends "./multiple_import_plugin_base.gd"
 
 
 func _get_importer_name():
@@ -26,32 +10,8 @@ func _get_visible_name():
 	return "Aseprite SpriteFrames (Split By Layer)"
 
 
-func _get_recognized_extensions():
-	return ["aseprite", "ase"]
-
-
-func _get_save_extension():
-	return "json"
-
-
-func _get_resource_type():
-	return "JSON"
-
-
-func _get_preset_count():
-	return 1
-
-
-func _get_preset_name(i):
-	return "Default"
-
-
 func _get_priority():
 	return 2.0 if config.get_default_importer() == config.IMPORTER_SPRITEFRAMES_SPLIT_NAME else 1.0
-
-
-func _get_import_order():
-	return 1
 
 
 func _get_import_options(_path, _i):
@@ -77,61 +37,13 @@ func _get_import_options(_path, _i):
 	]
 
 
-func _get_option_visibility(path, option, options):
-	return true
+func _layer_extension() -> String:
+	return "ase_layer"
 
 
-func _import(source_file, save_path, options, platform_variants, gen_files):
-	var exception_pattern = options.get('layer/exclude_layers_pattern', "")
-	var should_include_only_visibles = options.get('layer/only_visible_layers', false)
-	
-	var absolute_source_file = ProjectSettings.globalize_path(source_file)
-
-	var layers = _aseprite.list_valid_layers(
-		absolute_source_file,
-		exception_pattern,
-		should_include_only_visibles
-	)
-	
-	var layers_resources_folder = options["output/layers_resources_folder"]
-
-	var import_options = {
-		"source": source_file,
+func _get_base_import_options(options: Dictionary):
+	return  {
 		"sheet_type": options["sheet/sheet_type"],
 		"sheet_columns": options["sheet/sheet_columns"],
 		"should_round_fps": options["animation/round_fps"],
 	}
-
-	var base_name = source_file.get_basename()
-	
-	if layers_resources_folder != "":
-		if not DirAccess.dir_exists_absolute(layers_resources_folder):
-			DirAccess.make_dir_recursive_absolute(layers_resources_folder)
-		base_name = "%s/%s" % [layers_resources_folder, base_name.get_file()]
-
-	for layer in layers:
-		var layer_save_path = "%s_l_%s.ase_layer" % [base_name, layer]
-		var file = FileAccess.open(layer_save_path, FileAccess.WRITE)
-		file.store_string(JSON.stringify({
-			"layer": layer,
-			"import_options": import_options,
-		}))
-
-	var data_to_save = {
-		"layers": layers
-	}
-
-	var json = JSON.new()
-	json.data = data_to_save
-
-	var exit_code = ResourceSaver.save(json, "%s.%s" % [save_path, _get_save_extension()])
-
-	# TODO should implement cleanup?
-	# - idea:
-	#     - save generated layers path to this file
-	#     - on import load it (if it still exists
-	#     - on importing new, check which ones are not in the new list anymore and remove them
-
-	file_system_helper.schedule_file_system_scan()
-
-	return exit_code

--- a/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
@@ -1,0 +1,137 @@
+@tool
+extends EditorImportPlugin
+
+const result_codes = preload("../config/result_codes.gd")
+
+var config = preload("../config/config.gd").new()
+#var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
+var _aseprite = preload("../aseprite/aseprite.gd").new()
+#var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
+#var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
+
+
+# TODO remove split option from main importer
+
+var file_system_helper
+
+func _init(fs_helper) -> void:
+	file_system_helper = fs_helper
+
+
+func _get_importer_name():
+	return "aseprite_wizard.plugin.spriteframes-split"
+
+
+func _get_visible_name():
+	return "Aseprite SpriteFrames (Split By Layer)"
+
+
+func _get_recognized_extensions():
+	return ["aseprite", "ase"]
+
+
+func _get_save_extension():
+	return "json"
+
+
+func _get_resource_type():
+	return "JSON"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_priority():
+	return 2.0 if config.get_default_importer() == config.IMPORTER_SPRITEFRAMES_SPLIT_NAME else 1.0
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_import_options(_path, _i):
+	return [
+		{"name": "layer/exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
+		{"name": "layer/only_visible_layers",    "default_value": false},
+		{
+			"name": "sheet/sheet_type",
+			"default_value": "packed",
+			"property_hint": PROPERTY_HINT_ENUM,
+			"hint_string": "columns,horizontal,vertical,packed",
+		},
+		{
+			"name": "sheet/sheet_columns",
+			"default_value": 12,
+		},
+		{"name": "animation/round_fps", "default_value": true},
+		{
+			"name": "output/layers_resources_folder",
+			"default_value": "",
+			"property_hint": PROPERTY_HINT_DIR,
+		}
+	]
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _import(source_file, save_path, options, platform_variants, gen_files):
+	var exception_pattern = options.get('layer/exclude_layers_pattern', "")
+	var should_include_only_visibles = options.get('layer/only_visible_layers', false)
+	
+	var absolute_source_file = ProjectSettings.globalize_path(source_file)
+
+	var layers = _aseprite.list_valid_layers(
+		absolute_source_file,
+		exception_pattern,
+		should_include_only_visibles
+	)
+	
+	var layers_resources_folder = options["output/layers_resources_folder"]
+
+	var import_options = {
+		"source": source_file,
+		"sheet_type": options["sheet/sheet_type"],
+		"sheet_columns": options["sheet/sheet_columns"],
+		"should_round_fps": options["animation/round_fps"],
+	}
+
+	var base_name = source_file.get_basename()
+	
+	if layers_resources_folder != "":
+		if not DirAccess.dir_exists_absolute(layers_resources_folder):
+			DirAccess.make_dir_recursive_absolute(layers_resources_folder)
+		base_name = "%s/%s" % [layers_resources_folder, base_name.get_file()]
+
+	for layer in layers:
+		var layer_save_path = "%s_l_%s.ase_layer" % [base_name, layer]
+		var file = FileAccess.open(layer_save_path, FileAccess.WRITE)
+		file.store_string(JSON.stringify({
+			"layer": layer,
+			"import_options": import_options,
+		}))
+
+	var data_to_save = {
+		"layers": layers
+	}
+
+	var json = JSON.new()
+	json.data = data_to_save
+
+	var exit_code = ResourceSaver.save(json, "%s.%s" % [save_path, _get_save_extension()])
+
+	# TODO should implement cleanup?
+	# - idea:
+	#     - save generated layers path to this file
+	#     - on import load it (if it still exists
+	#     - on importing new, check which ones are not in the new list anymore and remove them
+
+	file_system_helper.schedule_file_system_scan()
+
+	return exit_code

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
@@ -1,0 +1,71 @@
+@tool
+extends EditorImportPlugin
+
+const result_codes = preload("../config/result_codes.gd")
+var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
+
+var config = preload("../config/config.gd").new()
+
+
+func _get_save_extension():
+	return "res"
+
+
+func _get_resource_type():
+	return "PortableCompressedTexture2D"
+
+
+func _get_preset_count():
+	return 1
+
+
+func _get_preset_name(i):
+	return "Default"
+
+
+func _get_import_order():
+	return 1
+
+
+func _get_option_visibility(path, option, options):
+	return true
+
+
+func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dictionary:
+	var result = _aseprite_file_exporter.generate_aseprite_file(absolute_source_file, options)
+
+	if not result.is_ok:
+		return result
+
+	var sprite_sheet = result.content.sprite_sheet
+	var data_result = _aseprite_file_exporter.load_json_content(result.content.data_file)
+
+	if not data_result.is_ok:
+		return data_result
+
+	var data = data_result.content
+
+	return result_codes.result({
+		"data_file": result.content.data_file,
+		"sprite_sheet": sprite_sheet,
+		"data": data
+	})
+
+
+func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
+	var image = Image.load_from_file(sprite_sheet)
+
+	var tex := PortableCompressedTexture2D.new()
+	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+#
+	var exit_code = ResourceSaver.save(tex, "%s.%s" % [save_path, _get_save_extension()])
+
+	if config.should_remove_source_files():
+		DirAccess.remove_absolute(data_file_path)
+		DirAccess.remove_absolute(sprite_sheet)
+
+	if exit_code != OK:
+		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		return FAILED
+
+	return OK

--- a/addons/AsepriteWizard/importers/static_texture_multiple_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_multiple_import_plugin.gd
@@ -1,0 +1,34 @@
+@tool
+extends "./multiple_import_plugin_base.gd"
+
+
+func _get_importer_name():
+	return "aseprite_wizard.plugin.static-texture-split"
+
+
+func _get_visible_name():
+	return "Aseprite Texture (Split By Layer)"
+
+
+func _get_priority():
+	return 2.0 if config.get_default_importer() == config.IMPORTER_STATIC_TEXTURE_SPLIT_NAME else 1.0
+
+
+func _get_import_options(_path, _i):
+	return [
+		{"name": "layer/exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
+		{"name": "layer/only_visible_layers",    "default_value": false},
+		{
+			"name": "output/layers_resources_folder",
+			"default_value": "",
+			"property_hint": PROPERTY_HINT_DIR,
+		}
+	]
+
+
+func _layer_extension() -> String:
+	return "ase_layer_tex"
+
+
+func _get_base_import_options(options: Dictionary):
+	return  {}

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -4,8 +4,11 @@ extends EditorPlugin
 # importers
 const NoopImportPlugin = preload("importers/noop_import_plugin.gd")
 const SpriteFramesImportPlugin = preload("importers/sprite_frames_import_plugin.gd")
+const SpriteFramesSplitImportPlugin = preload("res://addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd")
 const TilesetTextureImportPlugin = preload("importers/tileset_texture_import_plugin.gd")
 const TextureImportPlugin = preload("importers/static_texture_import_plugin.gd")
+const LayerSpriteFramesImportPlugin = preload("res://addons/AsepriteWizard/importers/layer_import_plugin.gd")
+const FileSystemHelper = preload("importers/helpers/file_system_helper.gd")
 # export
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
 # interface
@@ -30,6 +33,8 @@ var imports_list_panel: MarginContainer
 var export_plugin : EditorExportPlugin
 var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
+
+var file_system_helper
 
 var _exporter_enabled = false
 
@@ -76,11 +81,16 @@ func _remove_menu_entries():
 
 
 func _setup_importer():
+	file_system_helper = FileSystemHelper.new()
+	add_child(file_system_helper)
+
 	_importers = [
 		NoopImportPlugin.new(),
 		SpriteFramesImportPlugin.new(),
+		SpriteFramesSplitImportPlugin.new(file_system_helper),
 		TilesetTextureImportPlugin.new(),
 		TextureImportPlugin.new(),
+		LayerSpriteFramesImportPlugin.new(),
 	]
 
 	for i in _importers:
@@ -90,6 +100,10 @@ func _setup_importer():
 func _remove_importer():
 	for i in _importers:
 		remove_import_plugin(i)
+
+	if file_system_helper != null:
+		file_system_helper.queue_free()
+		file_system_helper = null
 
 
 func _setup_exporter():

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -7,7 +7,9 @@ const SpriteFramesImportPlugin = preload("importers/sprite_frames_import_plugin.
 const SpriteFramesSplitImportPlugin = preload("res://addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd")
 const TilesetTextureImportPlugin = preload("importers/tileset_texture_import_plugin.gd")
 const TextureImportPlugin = preload("importers/static_texture_import_plugin.gd")
-const LayerSpriteFramesImportPlugin = preload("res://addons/AsepriteWizard/importers/layer_import_plugin.gd")
+const TextureSplitImportPlugin = preload("res://addons/AsepriteWizard/importers/static_texture_multiple_import_plugin.gd")
+const LayerSpriteFramesImportPlugin = preload("res://addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd")
+const LayerTextureImportPlugin = preload("res://addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd")
 const FileSystemHelper = preload("importers/helpers/file_system_helper.gd")
 # export
 const ExportPlugin = preload("export/metadata_export_plugin.gd")
@@ -90,7 +92,9 @@ func _setup_importer():
 		SpriteFramesSplitImportPlugin.new(file_system_helper),
 		TilesetTextureImportPlugin.new(),
 		TextureImportPlugin.new(),
+		TextureSplitImportPlugin.new(file_system_helper),
 		LayerSpriteFramesImportPlugin.new(),
+		LayerTextureImportPlugin.new(),
 	]
 
 	for i in _importers:


### PR DESCRIPTION
Implemented new importer flow for imports. This aims to solve a few issues.

**This is a breaking change.**

The new importers (`Aseprite SpriteFrames (Split By Layer)` and `Aseprite Texture (Split By Layer)` create one resource for each layer. The actual aseprite file is interpreted as a json file, and holds references to all layers imported.

The SpriteFrames Split Importer will generate  `.ase_layer` files, while the Aseprite Split Texture Importer will generate `.ase_layer_tex` files. There is one importer for each type, which will allow using these files as their respective resources (SpriteFrames and Texture).

This new flow solves a few problems:
- As importers import resources in one specific type, when using the split option in SpriteFrames, the root file had to be set to the first layer, which was confusing.
- Cleaning up resources for layers was impossible before, but now it's being done thanks to the root file being able to hold references to all layers
- The new importers allow selecting an output folder, so layer resources can be exported to a specific folder, helping with organisation
- This will solve #152 

In this PR I'm also:
- Organising import properties
- Renamed SpriteFrames importer id for consistency