### PR TITLE
Fix SpriteFrames imported via custom importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Renamed SpriteFrames importer id for consistency
 - Removed Split option from SpriteFrames importer. Split are handled in separate importers.
 
+### Removed
+
+- Removed option to disable the exporter plugin, because now it's required for importing textures correctly.
+
 ## 8.2.0 (2024-11-22)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ For project specific configurations check `Project -> Project Settings -> Genera
 | Animation > Layer > Only Include Visible Layers By Default | Default configuration for "only visible" in the docks. Default: false |
 | Animation > Loop > Enabled | Enables animation loop by default. Default: `true` |
 | Animation > Loop > Exception Prefix | Animations with this prefix are imported with opposite loop configuration. For example, if your default configuration is Loop = true, animations starting with `_` would have Loop = false. The prefix is removed from the animation name on import (i.e  `_death` > `death`). Default: `_` |
-| Animation > Storage > Enable Metadata Removal on Export | Removes dock metadata from scene when exporting the project. Ensures no local info is shipped with the app. Default: `true` |
 | Import > Cleanup > Remove Json File | Remove temporary `*.json` files generated during import. Default: `true` |
 | Import > Cleanup > Automatically Hide Sprites Not In Animation | Default configuration for AnimationPlayer option to hide sprite when not in animation. Default: `false` |
 | Import > Import Plugin > Default Automatic Importer | Which importer to use by default for aseprite files. Options: `No Import`, `SpriteFrames`, `Static Texture`, `Tileset Texture`. Default: `No Import` |
@@ -324,10 +323,6 @@ Both the default configuration and the exception prefix can be changed in the co
 ### Import overwrite previous files
 
 Currently, import overwrites previously imported files. Any manual modification in the previous resource file will be lost.
-
-### Metadata cleanup on export
-
-The options you select in the inspector dock are stored in the scene as metadata. As you can select files from anywhere in your system, there is an export plugin to prevent your local path metadata to be shipped with the game. In case you suspect this is conflicting with other plugins (or if you think you don't need it) you can disable it at `Project > Project Settings > General > Animation > Storage > Enable Metadata Removal On Export`.
 
 ## Known Issues
 

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -37,9 +37,6 @@ const _HISTORY_DEFAULT_MAX_ENTRIES = 100
 # SpriteFrames import last config
 const _STANDALONE_SPRITEFRAMES_LAST_IMPORT_CFG = "standalone_sf_last_import_cfg"
 
-# export
-const _EXPORTER_ENABLE_KEY = 'aseprite/animation/storage/enable_metadata_removal_on_export'
-
 var _editor_settings: EditorSettings = EditorInterface.get_editor_settings()
 
 #######################################################
@@ -72,10 +69,6 @@ func is_importer_enabled() -> bool:
 
 func get_default_importer() -> String:
 	return _get_project_setting(_DEFAULT_IMPORTER_KEY, IMPORTER_SPRITEFRAMES_NAME if is_importer_enabled() else IMPORTER_NOOP_NAME)
-
-
-func is_exporter_enabled() -> bool:
-	return _get_project_setting(_EXPORTER_ENABLE_KEY, true)
 
 
 func should_remove_source_files() -> bool:
@@ -163,8 +156,6 @@ func initialize_project_settings():
 		])
 	)
 
-	_initialize_project_cfg(_EXPORTER_ENABLE_KEY, true, TYPE_BOOL)
-
 	_initialize_project_cfg(_HISTORY_MAX_ENTRIES, _HISTORY_DEFAULT_MAX_ENTRIES, TYPE_INT)
 
 	_initialize_project_cfg(_SET_VISIBLE_TRACK_AUTOMATICALLY, false, TYPE_BOOL)
@@ -181,7 +172,6 @@ func clear_project_settings():
 		_LOOP_EXCEPTION_PREFIX,
 		_REMOVE_SOURCE_FILES_KEY,
 		_DEFAULT_IMPORTER_KEY,
-		_EXPORTER_ENABLE_KEY,
 		_HISTORY_MAX_ENTRIES,
 		_SET_VISIBLE_TRACK_AUTOMATICALLY,
 		_DEFAULT_ONLY_VISIBLE_LAYERS,

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -88,6 +88,8 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		return FAILED
 
 	var resource = resources.content[0]
+	resource.resource.set_meta("imported_via_aw", true)
+
 	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -100,14 +100,14 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
 		return FAILED
 
-	var resource = resources.content[0]
+	var resource: Dictionary = resources.content[0]
+	resource.resource.set_meta("imported_via_aw", true)
 	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)
 
-
-	for extra_file in resource.extra_gen_files:
-		gen_files.push_back(extra_file)
+	#for extra_file in resource.extra_gen_files:
+		#gen_files.push_back(extra_file)
 
 	if config.should_remove_source_files():
 		_remove_source_files(source_files.content)

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -12,7 +12,7 @@ const LayerSpriteFramesImportPlugin = preload("res://addons/AsepriteWizard/impor
 const LayerTextureImportPlugin = preload("res://addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd")
 const FileSystemHelper = preload("importers/helpers/file_system_helper.gd")
 # export
-const ExportPlugin = preload("export/metadata_export_plugin.gd")
+const ExportPlugin = preload("export/export_plugin.gd")
 # interface
 const ConfigDialog = preload('config/config_dialog.tscn')
 const WizardWindow = preload("interface/docks/wizard/as_wizard_dock_container.tscn")
@@ -37,8 +37,6 @@ var sprite_inspector_plugin: EditorInspectorPlugin
 var animated_sprite_inspector_plugin: EditorInspectorPlugin
 
 var file_system_helper
-
-var _exporter_enabled = false
 
 var _importers = []
 
@@ -111,16 +109,12 @@ func _remove_importer():
 
 
 func _setup_exporter():
-	if config.is_exporter_enabled():
-		export_plugin = ExportPlugin.new()
-		add_export_plugin(export_plugin)
-		_exporter_enabled = true
+	export_plugin = ExportPlugin.new()
+	add_export_plugin(export_plugin)
 
 
 func _remove_exporter():
-	if _exporter_enabled:
-		remove_export_plugin(export_plugin)
-		_exporter_enabled = false
+	remove_export_plugin(export_plugin)
 
 
 func _setup_sprite_inspector_plugin():


### PR DESCRIPTION
It seems that adding the texture files in the `gen_files` array on import is not enough to make them available in the exported game. To fix this, I'm explicitly adding the generated textures to the exported game using the export plugin.

As the export plugin is not optional anymore, I'm also removing the option to disable it.