### PR TITLE
Better tileset importer error message and invalid data file handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## Unreleased
 
 ### Added
+
 - Added option to Texture and Texture (split) importers to import the full spritesheet instead of just the first frame.
 - Added option to Texture (split) importer to not export duplicated layers and trim spritesheet cells.
 
+### Changed
+
+- Better error message when Tileset importer fails due to bad data file. Now it warns the user that the file should have at least one tilemap layer.
+
+### Fixed
+
+- Make sure parameter is not null when validating data file, so it doesn't print obscure errors.
 
 ### Thanks
 
 - Thanks @Bastani for suggesting and implementing the texture importers improvements.
+- Thansk @lashtear and @jupsky for detecting and reporting the Tileset importer issue.
 
 
 ## 9.0.0 (2025-02-06)

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -296,7 +296,7 @@ func test_command():
 
 
 func is_valid_spritesheet(content):
-	return content.has("frames") and content.has("meta") and content.meta.has('image')
+	return content is Dictionary and content.has("frames") and content.has("meta") and content.meta.has('image')
 
 
 func get_content_frames(content):

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -88,7 +88,11 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var result = _generate_texture(absolute_source_file, aseprite_opts)
 
 	if not result.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(result.code))
+		var extra_error_info = ""
+		if result.code == result_codes.ERR_INVALID_ASEPRITE_SPRITESHEET:
+			extra_error_info = " Make sure your Aseprite file contains at least one Tilemap layer."
+
+		printerr("ERROR - Could not import aseprite file: %s.%s" % [result_codes.get_error_message(result.code), extra_error_info])
 		return FAILED
 
 	var sprite_sheet = result.content.sprite_sheet


### PR DESCRIPTION
Closes #195 

- Check if parameter is a valid dictionary when validating the data file, to prevent this kind of obscure error:
`res://addons/AsepriteWizard/aseprite/aseprite.gd:244 - Invalid call. Nonexistent function 'has' in base 'Nil'.`
- Improved error message when the Tileset importer fails due to bad Aseprite file. Now the message hints to check if the file contains at least one tilemap layer. 