### PR TITLE
Change "Multiple file" importers root file to PackedDataContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - Better error message when Tileset importer fails due to bad data file. Now it warns the user that the file should have at least one tilemap layer.
+- "Multiple file" importers (Texture split, SpritaFrames split) saves root file as PackedDataContainer instead of JSON to prevent them from opening in the script editor.
 
 ### Fixed
 
@@ -21,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Thanks @Bastani for suggesting and implementing the texture importers improvements.
 - Thansk @lashtear and @jupsky for detecting and reporting the Tileset importer issue.
+- Thanks @jupsky for reporting the 'Multiple file' importer type caveat and @Bastani for identifying the root cause.
 
 
 ## 9.0.0 (2025-02-06)

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -17,11 +17,11 @@ func _get_recognized_extensions():
 
 
 func _get_save_extension():
-	return "json"
+	return "res"
 
 
 func _get_resource_type():
-	return "JSON"
+	return "PackedDataContainer"
 
 
 func _get_preset_count():
@@ -80,10 +80,10 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		}))
 		data_to_save.layers[layer] = layer_save_path
 
-	var json = JSON.new()
-	json.data = data_to_save
+	var packed = PackedDataContainer.new()
+	packed.pack(data_to_save)
 
-	var exit_code = ResourceSaver.save(json, "%s.%s" % [save_path, _get_save_extension()])
+	var exit_code = ResourceSaver.save(packed, "%s.%s" % [save_path, _get_save_extension()])
 
 	_cleanup_old_layers(old_data, layers)
 
@@ -104,14 +104,29 @@ func _load_old_data(source_file: String):
 
 	if ResourceLoader.exists(source_file):
 		var d = ResourceLoader.load(source_file)
+		# handling JSON to keep it backwards compatible
+		# remove it in the next major version
 		if d is JSON:
 			old_data = d.data.layers
+		elif d is PackedDataContainer:
+			old_data = _packed_container_to_dictionary(d["layers"])
 
 	return old_data
 
 
+func _packed_container_to_dictionary(packed):
+	var dic = {}
+	for k in packed:
+		if packed[k] is PackedDataContainerRef:
+			dic[k] = _packed_container_to_dictionary(packed[k])
+		else:
+			dic[k] = packed[k]
+	return dic
+
+
 func _cleanup_old_layers(old_data: Dictionary, layers: Array):
 	var old_layers = old_data.keys()
+
 	for old_layer in old_layers:
 		if not layers.has(old_layer):
 			var file = old_data[old_layer]


### PR DESCRIPTION
In the current version, "Multiple file" importers root files are saved as JSON. As reported in the issue #204, as the editor understands these files as JSON, it allows opening them in the Script Editor, triggering some annoying and confusing messages when saving like this:

![image](https://github.com/user-attachments/assets/ff4541e0-c10a-4894-aaec-d46014c4777a)

To prevent this, the root files are now being saved as PackedDataContainer.

This change is backwards compatible. Existing files should keep working, but the type change will only happen on re-import.

Closes #204 