### PR TITLE
Add support for frame padding in sprite sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Options:
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 | Sheet type | Algorithm to create spritesheet. Options: columns, horizontal, vertical, packed. Default: Packed|
 | Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.
+| Frame padding | Padding in pixels to add around each frame. This can help deal with textures bleeding across frames. Default: 0.
 | Animation / Round FPS | When selected, animation FPS is rounded to next integer. Default: true.|
 
 ###### SpriteFrames split by layer
@@ -139,6 +140,7 @@ Texture importer options:
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 | Sheet type | Algorithm to create spritesheet. Options: columns, horizontal, vertical, packed. Default: columns|
 | Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.|
+| Frame padding | Padding in pixels to add around each frame. This can help deal with textures bleeding across frames. Default: 0.
 
 ######  Static image split by layer
 
@@ -166,6 +168,7 @@ Tileset importer options:
 | Only include visible layers | If selected it only includes in the image file the layers visible in Aseprite. If not selected, all layers are exported, regardless of visibility.|
 | Sheet type | Algorithm to create spritesheet. Options: columns, horizontal, vertical, packed. Default: columns|
 | Sheet column | Only applied when sheet type is "columns". Defines the number of columns in the spritesheet. If "0", packed algorithm is used. Default: 12.
+| Frame padding | Padding in pixels to add around each frame. This can help deal with textures bleeding across frames. Default: 0.
 
 ### Inspector Docks
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -128,6 +128,10 @@ func _add_sheet_type_arguments(arguments: Array, options : Dictionary):
 		arguments.push_back("--sheet-type")
 		arguments.push_back(sheet_type)
 
+	var frame_padding = options.get("frame_padding", 0)
+	arguments.push_back("--shape-padding")
+	arguments.push_back(frame_padding)
+
 
 func _get_exception_layers(file_name: String, exception_pattern: String) -> Array:
 	var layers = list_layers(file_name)

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -62,6 +62,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	
 	var export_options = {
 		"sheet_type": data.import_options.sheet_type,
+		"frame_padding": data.import_options.frame_padding,
 		"sheet_columns": data.import_options.sheet_columns,
 		"should_round_fps": data.import_options.should_round_fps,
 	}

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -59,6 +59,10 @@ func _get_import_options(_path, _i):
 			"name": "sheet/sheet_columns",
 			"default_value": 12,
 		},
+		{
+			"name": "sheet/frame_padding",
+			"default_value": 0,
+		},
 		{"name": "animation/round_fps", "default_value": true},
 	]
 
@@ -82,6 +86,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		"output_filename": '',
 		"output_folder": source_path,
 		"sheet_type": options["sheet/sheet_type"],
+		"frame_padding": options["sheet/frame_padding"],
 		"sheet_columns": options["sheet/sheet_columns"],
 	}
 

--- a/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_multiple_import_plugin.gd
@@ -28,6 +28,10 @@ func _get_import_options(_path, _i):
 			"name": "sheet/sheet_columns",
 			"default_value": 12,
 		},
+		{
+			"name": "sheet/frame_padding",
+			"default_value": 0,
+		},
 		{"name": "animation/round_fps", "default_value": true},
 		{
 			"name": "output/layers_resources_folder",
@@ -44,6 +48,7 @@ func _layer_extension() -> String:
 func _get_base_import_options(options: Dictionary):
 	return  {
 		"sheet_type": options["sheet/sheet_type"],
+		"frame_padding": options["sheet/frame_padding"],
 		"sheet_columns": options["sheet/sheet_columns"],
 		"should_round_fps": options["animation/round_fps"],
 	}

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -63,6 +63,10 @@ func _get_import_options(_path, _i):
 			"name": "sheet/sheet_columns",
 			"default_value": 12,
 		},
+		{
+			"name": "sheet/frame_padding",
+			"default_value": 0,
+		},
 	]
 
 func _get_option_visibility(path, option, options):
@@ -82,6 +86,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		"output_filename": '',
 		"output_folder": source_path,
 		"sheet_type": options["sheet/sheet_type"],
+		"frame_padding": options["sheet/frame_padding"],
 		"sheet_columns": options["sheet/sheet_columns"],
 	}
 


### PR DESCRIPTION
This adds a Frame Spacing option which optionally adds extra padding around each frame in a sprite sheet.

closes #209 