### PR TITLE
Support UID in docks and imports manager

### DIFF
--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -11,6 +11,7 @@ var target_node: Node
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
 
 var _slice: String = ""
+var _source_uid: int = -1
 var _source: String = ""
 var _file_dialog_aseprite: EditorFileDialog
 var _output_folder_dialog: EditorFileDialog
@@ -168,7 +169,7 @@ func _setup_config():
 
 func _load_common_config(cfg):
 	if cfg.has("source"):
-		_set_source(cfg.source)
+		_set_source(cfg.source, cfg.get("source_uid", -1))
 
 	# keeping this to be backwards compatible
 	if cfg.get("layer", "") != "":
@@ -208,7 +209,20 @@ func _load_common_default_config():
 	_load_default_config()
 
 
-func _set_source(source):
+func _set_source(source, uid: int = -1):
+	if uid == -1 or not ResourceUID.has_id(uid):
+		if ResourceLoader.exists(source):
+			_source_uid = ResourceLoader.get_resource_uid(source)
+	else:
+		_source_uid = uid
+		var source_path = ResourceUID.get_id_path(uid)
+		_set_source_fields(source_path)
+		return
+
+	_set_source_fields(source)
+
+
+func _set_source_fields(source):
 	_source = source
 	_source_field.text = _source
 	_source_field.tooltip_text = _source
@@ -337,6 +351,7 @@ func _get_current_config():
 
 	var cfg := {
 		"source": _source,
+		"source_uid": _source_uid,
 		"layers": _layer_field.get_selected_layers(),
 		"slice": _slice,
 		"o_folder": _output_folder,

--- a/addons/AsepriteWizard/interface/imports_manager/import_helper.gd
+++ b/addons/AsepriteWizard/interface/imports_manager/import_helper.gd
@@ -31,7 +31,7 @@ func _sprite_frames_import(node: Node, resource_config: Dictionary) -> void:
 		printerr("Node config missing information.")
 		return
 
-	var source = ProjectSettings.globalize_path(config.source)
+	var source = ProjectSettings.globalize_path(_get_updated_source_path(config))
 	var options = _parse_import_options(config, resource_config.scene_path.get_base_dir())
 
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source, options)
@@ -67,7 +67,7 @@ func _animation_import(node: Node, root_node: Node, resource_config: Dictionary)
 
 func _import_to_animation_player(node: Node, root: Node, resource_config: Dictionary) -> void:
 	var config = resource_config.meta
-	var source = ProjectSettings.globalize_path(config.source)
+	var source = ProjectSettings.globalize_path(_get_updated_source_path(config))
 	var options = _parse_import_options(config, resource_config.scene_path.get_base_dir())
 
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source, options)
@@ -94,7 +94,7 @@ func _import_to_animation_player(node: Node, root: Node, resource_config: Dictio
 
 func _import_static(node: Node, resource_config: Dictionary) -> void:
 	var config = resource_config.meta
-	var source = ProjectSettings.globalize_path(config.source)
+	var source = ProjectSettings.globalize_path(_get_updated_source_path(config))
 	var options = _parse_import_options(config, resource_config.scene_path.get_base_dir())
 	options["first_frame_only"] = true
 
@@ -138,3 +138,10 @@ func _handle_cleanup(aseprite_content, should_remove_spritesheet: bool):
 				DirAccess.remove_absolute(import_file)
 
 		EditorInterface.get_resource_filesystem().scan()
+
+
+func _get_updated_source_path(config) -> String:
+	var uid = config.get("source_uid", -1)
+	if uid != -1 and ResourceUID.has_id(uid):
+		return ResourceUID.get_id_path(uid)
+	return config.source

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,0 @@
-<!--
-template: home-redirect
--->
-# Redirecting page...
-
-This file content won't be used. This file is only here to generate a home using the 
-template set above. This template generates a page that redirects to the default locale.


### PR DESCRIPTION
Now when moving Aseprite files around, the docks will keep track of their location, as long as the UID feature is in use.

Closes #212 