### PR TITLE
Fix warning when loading image

### DIFF
--- a/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
+++ b/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
@@ -9,7 +9,7 @@ var _config = preload("../config/config.gd").new()
 
 
 func _load_compressed_texture(sprite_sheet: String) -> PortableCompressedTexture2D:
-	var image = Image.load_from_file(sprite_sheet)
+	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
 	return tex

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
@@ -53,7 +53,7 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 
 
 func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
-	var image = Image.load_from_file(sprite_sheet)
+	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -129,7 +129,7 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 
 
 func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
-	var image = Image.load_from_file(sprite_sheet)
+	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)


### PR DESCRIPTION
Fix scary warning when loading image:
```
WARNING: Loaded resource as image file, this will not work on export:  '...'.
Instead, import the image file as an Image resource and load it normally as a resource.
```
This warning does not apply to the usage in this plugin. As it is only triggered for local paths (`res://`),  I'm globalizing the image path so it goes away.