### PR TITLE
export cleanup: handle failure when saving temporary file resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ nav_max: 1
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+
+### Fixed
+
+- Skip cleanup when can't save temporary packed scene. This was causing issues when adding aseprite files to `tmx` files via YATI.
+- Export cleanup was using wrong cache path for temporary file.
+
+### Thanks
+
+- Thanks @molor3k for reporting the YATI issue.
+
 ## 9.4.0 (2025-07-09)
 
 ### Added


### PR DESCRIPTION
Solves #225 

On export, Aseprite wizard goes through the scenes that have animations imported and removes the metadata. This is done because the plugin allows aseprite files from outside the project folder, which contain the full path in your system, and most likely people don't want this information leaked on their games.

The issue here is that the tmx files are detected as PackedScenes, so they go through the same process. When injecting  Aseprite imported nodes in them, the plugin identifies the metadata and tries to remove it, but for some reason, when saving the scene, the process fails with a File: Unrecognized error..

This PR warns the failure on export, but still goes through with the game export. In case cleanup is important for the user, that should be done manually as part of the process that includes the animation to the tmx file (or whatever is the process that includes the animation into a packed scene no supported)