### PR TITLE
Polish snap to fps feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Unreleased
 
+### Added
+
+- Snap to FPS option for AnimationPlayer docks. When activated, Aseprite's integer frame durations will be recalculated to match the exact fractional timing of the target FPS. Useful for users that prefer to work with FPS instead of actual times.
 
 ### Fixed
 
@@ -15,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Thanks
 
+- Thanks @plagakit for implementing the Snap to FPS feature.
 - Thanks @molor3k for reporting the YATI issue.
 
 ## 9.4.0 (2025-07-09)

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -127,13 +127,13 @@ func _add_animation_frames(target_node: Node, player: AnimationPlayer, anim_name
 		for frame in frames:
 			var frame_key = _get_frame_key(target_node, frame, context, slice_rect)
 			animation.track_insert_key(frame_track_index, animation_length, frame_key)
-			
+
 			var duration = frame.duration
 			if options.get("convert_to_fps"):
 				var old_ms = options.get("convert_ms_field")
 				var target_fps = options.get("convert_fps_field")
 				duration = (frame.duration / old_ms) * (1000 / target_fps)
-			
+
 			animation_length += duration / 1000
 
 		# Godot 4 has an Animation.LOOP_PINGPONG mode, however it does not

--- a/addons/AsepriteWizard/interface/docks/dock_fields.tscn
+++ b/addons/AsepriteWizard/interface/docks/dock_fields.tscn
@@ -39,7 +39,7 @@ data = {
 [sub_resource type="ImageTexture" id="ImageTexture_bfypj"]
 image = SubResource("Image_qog2w")
 
-[sub_resource type="Image" id="Image_bfypj"]
+[sub_resource type="Image" id="Image_oxeky"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -49,7 +49,7 @@ data = {
 }
 
 [sub_resource type="ImageTexture" id="ImageTexture_qqpl1"]
-image = SubResource("Image_bfypj")
+image = SubResource("Image_oxeky")
 
 [node name="dock_fields" type="MarginContainer"]
 script = ExtResource("1_f3w00")
@@ -314,7 +314,6 @@ icon = SubResource("ImageTexture_qqpl1")
 alignment = 0
 
 [node name="section_content" type="MarginContainer" parent="VBoxContainer/extra/sections/animation"]
-visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
 
@@ -353,31 +352,41 @@ size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "On"
 
-[node name="convert_to_fps" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content"]
+[node name="snap_to_fps" type="VBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content"]
 layout_mode = 2
 tooltip_text = "If active, Aseprite frame durations will be converted from their integer millisecond values to match the exact fractional timing of the target FPS."
 
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_to_fps"]
+[node name="convert_to_fps" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps"]
+layout_mode = 2
+tooltip_text = "If active, Aseprite frame durations will be converted from their integer millisecond values to match the exact fractional timing of the target FPS."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_to_fps"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "Snap to FPS"
 
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_to_fps"]
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_to_fps"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
 text = "On"
 
-[node name="convert_ratio" type="VBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content"]
+[node name="convert_ratio_container" type="MarginContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps"]
+visible = false
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="convert_ratio" type="VBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container"]
 layout_mode = 2
 tooltip_text = "For example, if set to 16 ms = 1/60 FPS, a frame with a duration of 320 ms becomes 333.33 ms."
 
-[node name="ms" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio"]
+[node name="ms" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio"]
 layout_mode = 2
-alignment = 1
 
-[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/ms"]
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/ms"]
 layout_mode = 2
 min_value = 1.0
 max_value = 1000.0
@@ -385,43 +394,37 @@ value = 16.0
 rounded = true
 allow_greater = true
 
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/ms"]
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/ms"]
 layout_mode = 2
 size_flags_stretch_ratio = 2.0
 text = "ms in Aseprite"
 
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio"]
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio"]
 layout_mode = 2
-text = "converts to:"
+text = "="
 horizontal_alignment = 1
 
-[node name="fps" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio"]
-layout_mode = 2
-alignment = 1
-
-[node name="fraction" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps"]
+[node name="fps" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps/fraction"]
+[node name="fraction" type="HBoxContainer" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps"]
 layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "1/"
 
-[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps/fraction"]
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps/fraction"]
 layout_mode = 2
 min_value = 1.0
 max_value = 1000.0
 value = 60.0
 rounded = true
 allow_greater = true
+prefix = "1/"
 
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps"]
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps"]
 layout_mode = 2
 size_flags_stretch_ratio = 2.0
 text = "FPS in Godot"
 
-[node name="ms" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps"]
+[node name="ms" type="Label" parent="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps"]
 layout_mode = 2
 size_flags_stretch_ratio = 2.0
 text = "(16.667 ms)"
@@ -555,9 +558,9 @@ one_shot = true
 [connection signal="toggled" from="VBoxContainer/extra/sections/layers/section_content/content/visible_layers/CheckBox" to="." method="_on_visible_layer_toggled"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/animation/section_content/content/keep_length/CheckBox" to="." method="_on_keep_length_toggled"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/animation/section_content/content/auto_visible_track/CheckBox" to="." method="_on_anim_vis_toggled"]
-[connection signal="toggled" from="VBoxContainer/extra/sections/animation/section_content/content/convert_to_fps/CheckBox" to="." method="_on_anim_vis_toggled"]
-[connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/ms/SpinBox" to="." method="_on_spin_box_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps/fraction/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="toggled" from="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_to_fps/CheckBox" to="." method="_on_anim_vis_toggled"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/ms/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps/fraction/SpinBox" to="." method="_on_spin_box_value_changed"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/animation_sf/section_content/content/round_fps/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/output/section_content/content/embed/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="text_changed" from="VBoxContainer/extra/sections/output/section_content/content/out_filename/LineEdit" to="." method="_on_line_edit_text_changed"]

--- a/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
@@ -17,21 +17,22 @@ var static_texture_creator: StaticTextureCreator
 var _import_mode = -1
 var _animation_player_path: String
 
-@onready var _import_mode_options_field := $dock_fields/VBoxContainer/modes/options as OptionButton
-@onready var _animation_player_field := $dock_fields/VBoxContainer/animation_player/options as OptionButton
-@onready var _animation_player_container := $dock_fields/VBoxContainer/animation_player as HBoxContainer
+@onready var _import_mode_options_field: OptionButton = $dock_fields/VBoxContainer/modes/options
+@onready var _animation_player_field: OptionButton = $dock_fields/VBoxContainer/animation_player/options
+@onready var _animation_player_container: HBoxContainer = $dock_fields/VBoxContainer/animation_player
 
 # animation
-@onready var _animation_section := $dock_fields/VBoxContainer/extra/sections/animation as VBoxContainer
-@onready var _animation_section_header := $dock_fields/VBoxContainer/extra/sections/animation/section_header as Button
-@onready var _animation_section_container := $dock_fields/VBoxContainer/extra/sections/animation/section_content as MarginContainer
-@onready var _cleanup_hide_unused_nodes :=  $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/auto_visible_track/CheckBox as CheckBox
-@onready var _keep_length :=  $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/keep_length/CheckBox as CheckBox
-@onready var _convert_to_fps := $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/convert_to_fps/CheckBox as CheckBox
-@onready var _convert_section := $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/convert_ratio as VBoxContainer
-@onready var _convert_ms_field := $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/ms/SpinBox as SpinBox
-@onready var _convert_fps_field := $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps/fraction/SpinBox as SpinBox
-@onready var _converted_fps_label := $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/convert_ratio/fps/ms as Label
+@onready var _animation_section: VBoxContainer = $dock_fields/VBoxContainer/extra/sections/animation
+@onready var _animation_section_header: Button = $dock_fields/VBoxContainer/extra/sections/animation/section_header
+@onready var _animation_section_container: MarginContainer = $dock_fields/VBoxContainer/extra/sections/animation/section_content
+@onready var _cleanup_hide_unused_nodes: CheckBox =  $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/auto_visible_track/CheckBox
+@onready var _keep_length: CheckBox =  $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/keep_length/CheckBox
+@onready var _convert_to_fps: CheckBox = $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_to_fps/CheckBox
+
+@onready var _convert_section: MarginContainer = $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container
+@onready var _convert_ms_field: SpinBox = $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/ms/SpinBox
+@onready var _convert_fps_field: SpinBox = $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps/fraction/SpinBox
+@onready var _converted_fps_label: Label = $dock_fields/VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps/ms
 
 const INTERFACE_SECTION_KEY_ANIMATION = "animation_section"
 


### PR DESCRIPTION
- Hiding section which was exposed by default
- Changed layout a bit
- Unrelated: refactor type definitions in dock
- Added changelog

Old:
<img width="569" height="540" alt="Screenshot from 2025-08-05 17-54-19" src="https://github.com/user-attachments/assets/35829bf8-75ae-4254-8a65-10caf9df1e68" />


New:
<img width="569" height="520" alt="Screenshot from 2025-08-05 17-54-55" src="https://github.com/user-attachments/assets/2c159579-fa21-441b-8d71-876ddb6c46d1" />
