### PR TITLE
Made it so that ./ uses the current directory of the resource

### DIFF
--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -57,9 +57,9 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	var layers_resources_folder = options["output/layers_resources_folder"]
 
-	if layers_resources_folder.begins_with('./'):
-		var source_base_dir = source_file.get_base_dir();
-		layers_resources_folder = source_base_dir + layers_resources_folder.erase(0)
+	if layers_resources_folder.is_relative_path():
+	    var source_base_dir = source_file.get_base_dir()
+	    layer_resources_folder = source_base_dir.path_join(layers_resources_folder).simplify_path()
 
 	var import_options = _get_base_import_options(options)
 	import_options["source"] = source_file

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -57,6 +57,10 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	var layers_resources_folder = options["output/layers_resources_folder"]
 
+	if layers_resources_folder.begins_with('./'):
+		var source_base_dir = source_file.get_base_dir();
+		layers_resources_folder = source_base_dir + layers_resources_folder.erase(0)
+
 	var import_options = _get_base_import_options(options)
 	import_options["source"] = source_file
 


### PR DESCRIPTION
Just doing some refactoring and noticed that this wasn't the case.