### PR TITLE
feature: hierarchy layers loading

### DIFF
--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -158,13 +158,13 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
 	return exception_layers
 
 
-func list_valid_layers(file_path: String, exception_pattern: String = "", show_only_visible: bool = false, should_merge_duplicates: bool = false) -> Array:
+func list_valid_layers(file_path: String, exception_pattern: String = "", show_only_visible: bool = false, should_merge_duplicates: bool = false, no_groups: bool = false) -> Array:
 	var layers = []
 
 	if should_merge_duplicates:
 		layers = list_layers_without_duplicates(file_path, show_only_visible)
 	else:
-		layers = list_layers(file_path, show_only_visible)
+		layers = list_layers(file_path, show_only_visible, no_groups)
 
 	var exception_regex = _compile_regex(exception_pattern)
 
@@ -177,7 +177,7 @@ func list_valid_layers(file_path: String, exception_pattern: String = "", show_o
 	return output
 
 
-func list_layers(file_path: String, only_visible = false) -> Array:
+func list_layers(file_path: String, only_visible = false, no_groups: bool = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layer-hierarchy", file_path]
 
@@ -209,6 +209,8 @@ func list_layers(file_path: String, only_visible = false) -> Array:
 		if line.ends_with('/'):
 			var dir_name = line.rstrip('/').strip_edges()
 			stack.append(dir_name)
+			if not no_groups:
+				paths.append("/".join(stack))
 		else:
 			var file_name = line.strip_edges()
 			var full_path = '/'.join(stack + [file_name])

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -158,13 +158,13 @@ func _get_exception_layers(file_name: String, exception_pattern: String) -> Arra
 	return exception_layers
 
 
-func list_valid_layers(file_path: String, exception_pattern: String = "", show_only_visible: bool = false, should_merge_duplicates: bool = false, no_groups: bool = false) -> Array:
+func list_valid_layers(file_path: String, exception_pattern: String = "", show_only_visible: bool = false, should_merge_duplicates: bool = false, skip_group_layers: bool = false) -> Array:
 	var layers = []
 
 	if should_merge_duplicates:
 		layers = list_layers_without_duplicates(file_path, show_only_visible)
 	else:
-		layers = list_layers(file_path, show_only_visible, no_groups)
+		layers = list_layers(file_path, show_only_visible, skip_group_layers)
 
 	var exception_regex = _compile_regex(exception_pattern)
 
@@ -177,7 +177,7 @@ func list_valid_layers(file_path: String, exception_pattern: String = "", show_o
 	return output
 
 
-func list_layers(file_path: String, only_visible = false, no_groups: bool = false) -> Array:
+func list_layers(file_path: String, only_visible = false, skip_group_layers: bool = false) -> Array:
 	var output = []
 	var arguments = ["-b", "--list-layer-hierarchy", file_path]
 
@@ -209,7 +209,7 @@ func list_layers(file_path: String, only_visible = false, no_groups: bool = fals
 		if line.ends_with('/'):
 			var dir_name = line.rstrip('/').strip_edges()
 			stack.append(dir_name)
-			if not no_groups:
+			if not skip_group_layers:
 				paths.append("/".join(stack))
 		else:
 			var file_name = line.strip_edges()

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -72,7 +72,8 @@ func export_layers(file_name: String, output_folder: String, options: Dictionary
 func export_file_with_layers(file_name: String, layer_names: Array, output_folder: String, options: Dictionary) -> Dictionary:
 	var output_prefix = options.get('output_filename', "").strip_edges()
 	var output_dir = output_folder.replace("res://", "./").strip_edges()
-	var base_output_path = "%s/%s%s" % [output_dir, output_prefix, layer_names[0] if layer_names.size() == 1 else ""]
+	var flat_file_name = layer_names[0].replace("/", "_")
+	var base_output_path = "%s/%s%s" % [output_dir, output_prefix, flat_file_name if layer_names.size() == 1 else ""]
 	var data_file = "%s.json" % base_output_path
 	var sprite_sheet = "%s.png" % base_output_path
 	var trim_cels = options.get("trim_cels", false)
@@ -178,7 +179,7 @@ func list_valid_layers(file_path: String, exception_pattern: String = "", show_o
 
 func list_layers(file_path: String, only_visible = false) -> Array:
 	var output = []
-	var arguments = ["-b", "--list-layers", file_path]
+	var arguments = ["-b", "--list-layer-hierarchy", file_path]
 
 	if not only_visible:
 		arguments.push_front("--all-layers")
@@ -193,11 +194,26 @@ func list_layers(file_path: String, only_visible = false) -> Array:
 	if output.is_empty():
 		return output
 
-	var raw = output[0].split('\n')
-	var sanitized = []
-	for s in raw:
-		sanitized.append(s.strip_edges())
-	return sanitized
+	var lines: PackedStringArray = output[0].strip_edges().split('\n')
+	var paths = []
+	var stack = []
+	
+	for line in lines:
+		var indent_level = 0
+		while line.begins_with('  '):
+			indent_level += 1
+			line = line.substr(2)
+		
+		stack = stack.slice(0, indent_level)
+		
+		if line.ends_with('/'):
+			var dir_name = line.rstrip('/').strip_edges()
+			stack.append(dir_name)
+		else:
+			var file_name = line.strip_edges()
+			var full_path = '/'.join(stack + [file_name])
+			paths.append(full_path)
+	return paths
 
 
 func list_layers_without_duplicates(file_path: String, only_visible = false) -> Array:

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -58,8 +58,9 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var layers_resources_folder = options["output/layers_resources_folder"]
 
 	if layers_resources_folder.is_relative_path():
-	    var source_base_dir = source_file.get_base_dir()
-	    layer_resources_folder = source_base_dir.path_join(layers_resources_folder).simplify_path()
+		var source_base_dir = source_file.get_base_dir()
+		layers_resources_folder = source_base_dir.path_join(layers_resources_folder).simplify_path()
+
 
 	var import_options = _get_base_import_options(options)
 	import_options["source"] = source_file
@@ -76,7 +77,8 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	}
 
 	for layer in layers:
-		var layer_save_path = "%s_l_%s.%s" % [base_name, layer, _layer_extension()]
+		var flat_layer_name = (layer as String).replace("/", "_")
+		var layer_save_path = "%s_%s.%s" % [base_name, flat_layer_name, _layer_extension()]
 		var file = FileAccess.open(layer_save_path, FileAccess.WRITE)
 		file.store_string(JSON.stringify({
 			"layer": layer,

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -52,7 +52,8 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		absolute_source_file,
 		exception_pattern,
 		should_include_only_visibles,
-		should_merge_duplicates
+		should_merge_duplicates,
+		true
 	)
 
 	var layers_resources_folder = options["output/layers_resources_folder"]


### PR DESCRIPTION
I'm using hierarchy layers for my project and I have multiple sub-layers with same name. This could not be exported correctly.
So I found that from 1.2-beta2 Aseprite can export [layers](https://www.aseprite.org/docs/cli/#layer) from hierarchy.
Implemented this feature.
For example deep layer:
```
Group1\
  SubGroup\
    layer-name
```
Will became: `ProjectName_Group1_SubGroup_layer-name.ase_layer`
Now it skips group layers and build tree that represent in final file name (.ase_layer)