### PR TITLE
Fix SpriteFrames file importer cache

### DIFF
--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -95,6 +95,8 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)
+	ResourceLoader.load(resource_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
 
 	for extra_file in resource.extra_gen_files:
 		gen_files.push_back(extra_file)

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -115,9 +115,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)
-
-	#for extra_file in resource.extra_gen_files:
-		#gen_files.push_back(extra_file)
+	ResourceLoader.load(resource_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
 
 	if config.should_remove_source_files():
 		_remove_source_files(source_files.content)


### PR DESCRIPTION
Solution proposed on https://github.com/viniciusgerevini/godot-aseprite-wizard/discussions/238

Godot Editor's  was keeping the old resource cached, not showing updated textures in the editor. Adding an extra resource load to replace cache with newer version.