### PR TITLE
Implement bake files

### DIFF
--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -1,6 +1,7 @@
 @tool
 extends RefCounted
 
+const logger = preload("../config/logger.gd")
 var _config = preload("../config/config.gd").new()
 
 #
@@ -42,8 +43,7 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 
 	var exit_code = _execute(arguments, output)
 	if exit_code != 0:
-		printerr('aseprite: failed to export spritesheet')
-		printerr(output)
+		logger.error('Failed to export spritesheet: %s' % output, file_name)
 		return {}
 
 	return {
@@ -104,8 +104,7 @@ func export_file_with_layers(file_name: String, layer_names: Array, output_folde
 
 	var exit_code = _execute(arguments, output)
 	if exit_code != 0:
-		print('aseprite: failed to export layer spritesheet')
-		print(output)
+		logger.error('Failed to export layer spritesheet: %s' % output, file_name)
 		return {}
 
 	return {
@@ -187,8 +186,7 @@ func list_layers(file_path: String, only_visible = false, skip_group_layers: boo
 	var exit_code = _execute(arguments, output)
 
 	if exit_code != 0:
-		printerr('aseprite: failed listing layers')
-		printerr(output)
+		logger.error('Failed listing layers: %s' % output, file_path)
 		return []
 
 	if output.is_empty():
@@ -240,8 +238,7 @@ func list_layers_without_duplicates(file_path: String, only_visible = false) -> 
 	var exit_code = _execute(arguments, output)
 
 	if exit_code != 0:
-		printerr('aseprite: failed listing layers')
-		printerr(output)
+		logger.error('Failed listing layers: %s' % output, file_path)
 		return []
 
 	var file = FileAccess.open(data_path, FileAccess.READ)
@@ -271,8 +268,7 @@ func list_slices(file_name: String) -> Array:
 	var exit_code = _execute(arguments, output)
 
 	if exit_code != 0:
-		printerr('aseprite: failed listing slices')
-		printerr(output)
+		logger.error('Failed listing slices: %s' % output, file_name)
 		return []
 
 	if output.is_empty():
@@ -320,7 +316,7 @@ func _compile_regex(pattern):
 	if rgx.compile(pattern) == OK:
 		return rgx
 
-	printerr('exception regex error')
+	logger.error('Exception regex error')
 
 
 func test_command() -> bool:
@@ -384,8 +380,7 @@ func export_tileset_texture(file_name: String, output_folder: String, options: D
 
 	var exit_code = _execute(arguments, output)
 	if exit_code != 0:
-		printerr('aseprite: failed to export spritesheet')
-		printerr(output)
+		logger.error('Failed to export spritesheet: %s' % output, file_name)
 		return {}
 
 	return {

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -323,7 +323,7 @@ func _compile_regex(pattern):
 	printerr('exception regex error')
 
 
-func test_command():
+func test_command() -> bool:
 	var exit_code = OS.execute(_aseprite_command(), ['--version'], [], true)
 	return exit_code == 0
 

--- a/addons/AsepriteWizard/aseprite/file_exporter.gd
+++ b/addons/AsepriteWizard/aseprite/file_exporter.gd
@@ -146,3 +146,7 @@ func load_json_content(source_file: String) -> Dictionary:
 		return result_code.error(result_code.ERR_INVALID_ASEPRITE_SPRITESHEET)
 
 	return result_code.result(content)
+
+
+func is_aseprite_command_working() -> bool:
+	return _aseprite.test_command()

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -29,6 +29,8 @@ const IMPORTER_TILESET_TEXTURE_NAME = "Tileset Texture"
 const IMPORTER_STATIC_TEXTURE_NAME = "Static Texture"
 const IMPORTER_STATIC_TEXTURE_SPLIT_NAME = "Static Texture (Split By Layer)"
 
+const _IMPORTER_GENERATE_BAKE_FILE_KEY = 'aseprite/import/import_plugin/generate_bake_files'
+
 # wizard history
 const _WIZARD_HISTORY = "wizard_history"
 const _HISTORY_MAX_ENTRIES = 'aseprite/wizard/history/max_history_entries'
@@ -74,6 +76,10 @@ func is_importer_enabled() -> bool:
 
 func get_default_importer() -> String:
 	return _get_project_setting(_DEFAULT_IMPORTER_KEY, IMPORTER_SPRITEFRAMES_NAME if is_importer_enabled() else IMPORTER_NOOP_NAME)
+
+
+func should_generate_bake_files() -> bool:
+	return _get_project_setting(_IMPORTER_GENERATE_BAKE_FILE_KEY, false)
 
 
 func should_remove_source_files() -> bool:
@@ -160,6 +166,7 @@ func initialize_project_settings():
 			IMPORTER_STATIC_TEXTURE_SPLIT_NAME
 		])
 	)
+	_initialize_project_cfg(_IMPORTER_GENERATE_BAKE_FILE_KEY, false, TYPE_BOOL)
 
 	_initialize_project_cfg(_HISTORY_MAX_ENTRIES, _HISTORY_DEFAULT_MAX_ENTRIES, TYPE_INT)
 
@@ -180,6 +187,7 @@ func clear_project_settings():
 		_HISTORY_MAX_ENTRIES,
 		_SET_VISIBLE_TRACK_AUTOMATICALLY,
 		_DEFAULT_ONLY_VISIBLE_LAYERS,
+		_IMPORTER_GENERATE_BAKE_FILE_KEY,
 	]
 	for key in _all_settings:
 		ProjectSettings.clear(key)

--- a/addons/AsepriteWizard/config/logger.gd
+++ b/addons/AsepriteWizard/config/logger.gd
@@ -1,0 +1,21 @@
+@tool
+extends RefCounted
+
+const LOG_PREFIX = "[Aseprite Wizard] "
+
+static func info(message: String, file_name: String = "") -> void:
+	print(_build_log_line(message, file_name))
+
+
+static func error(message: String, file_name: String = "") -> void:
+	printerr(_build_log_line(message, file_name))
+
+
+static func warn(message: String, file_name: String = "") -> void:
+	print(_build_log_line("WARN: "+ message, file_name))
+
+
+static func _build_log_line(message: String, file_name: String) -> String:
+	if file_name == "":
+		return LOG_PREFIX + message
+	return "%s%s (%s)" % [LOG_PREFIX, message, file_name]

--- a/addons/AsepriteWizard/config/logger.gd.uid
+++ b/addons/AsepriteWizard/config/logger.gd.uid
@@ -1,0 +1,1 @@
+uid://bsaui5vs757mr

--- a/addons/AsepriteWizard/config/result_codes.gd
+++ b/addons/AsepriteWizard/config/result_codes.gd
@@ -23,6 +23,8 @@ static func get_error_message(code: int):
 			return "unable to import file"
 		ERR_INVALID_ASEPRITE_SPRITESHEET:
 			return "aseprite generated bad data file"
+		ERR_UNKNOWN_EXPORT_MODE:
+			return "wrong export mode"
 		ERR_NO_VALID_LAYERS_FOUND:
 			return "no valid layers found"
 		_:

--- a/addons/AsepriteWizard/config/result_codes.gd
+++ b/addons/AsepriteWizard/config/result_codes.gd
@@ -2,13 +2,13 @@
 extends RefCounted
 
 const SUCCESS = 0
-const ERR_ASEPRITE_CMD_NOT_FOUND = 1
-const ERR_SOURCE_FILE_NOT_FOUND = 2
-const ERR_OUTPUT_FOLDER_NOT_FOUND = 3
-const ERR_ASEPRITE_EXPORT_FAILED = 4
-const ERR_UNKNOWN_EXPORT_MODE = 5
-const ERR_NO_VALID_LAYERS_FOUND = 6
-const ERR_INVALID_ASEPRITE_SPRITESHEET = 7
+const ERR_ASEPRITE_CMD_NOT_FOUND = 991
+const ERR_SOURCE_FILE_NOT_FOUND = 992
+const ERR_OUTPUT_FOLDER_NOT_FOUND = 993
+const ERR_ASEPRITE_EXPORT_FAILED = 994
+const ERR_UNKNOWN_EXPORT_MODE = 995
+const ERR_NO_VALID_LAYERS_FOUND = 996
+const ERR_INVALID_ASEPRITE_SPRITESHEET = 997
 
 
 static func get_error_message(code: int):
@@ -26,7 +26,7 @@ static func get_error_message(code: int):
 		ERR_NO_VALID_LAYERS_FOUND:
 			return "no valid layers found"
 		_:
-			return "import failed with code %d" % code
+			return "import failed: %d" % error_string(code)
 
 
 static func error(error_code: int):

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -9,7 +9,7 @@ func create_animations(target_node: Node, player: AnimationPlayer,  aseprite_fil
 	var result = _import(target_node, player, aseprite_files, options)
 
 	if result != result_code.SUCCESS:
-		printerr(result_code.get_error_message(result))
+		logger.error(result_code.get_error_message(result))
 
 
 func _import(target_node: Node, player: AnimationPlayer, aseprite_files: Dictionary, options: Dictionary):

--- a/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
+++ b/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
@@ -1,6 +1,7 @@
 @tool
 extends RefCounted
 
+const logger = preload("../config/logger.gd")
 var result_code = preload("../config/result_codes.gd")
 var _aseprite = preload("../aseprite/aseprite.gd").new()
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()

--- a/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
+++ b/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
@@ -13,7 +13,7 @@ func _load_compressed_texture(sprite_sheet: String) -> PortableCompressedTexture
 	var global_path = ProjectSettings.globalize_path(sprite_sheet)
 	var image = Image.load_from_file(global_path)
 	if image == null or image.is_empty():
-		printerr("ERROR - Failed to load sprite sheet image: %s (resolved to: %s)" % [sprite_sheet, global_path])
+		logger.error('Failed to load sprite sheet image', sprite_sheet)
 		return null
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -13,7 +13,7 @@ enum {
 func create_animations(animated_sprite: Node, aseprite_files: Dictionary, options: Dictionary) -> void:
 	var sprite_frames_result = _create_sprite_frames(aseprite_files, options)
 	if not sprite_frames_result.is_ok:
-		printerr(result_code.get_error_message(sprite_frames_result.code))
+		logger.error(result_code.get_error_message(sprite_frames_result.code))
 		return
 
 	animated_sprite.frames = sprite_frames_result.content.resource
@@ -231,7 +231,7 @@ func create_packed_texture(sprite_sheet: String, save_path: String = "") -> Port
 
 	var exit_code = ResourceSaver.save(tex, save_path)
 	if exit_code != OK:
-		printerr(result_code.get_error_message(result_code.ERR_ASEPRITE_EXPORT_FAILED))
+		logger.error(result_code.get_error_message(result_code.ERR_ASEPRITE_EXPORT_FAILED), sprite_sheet)
 		return null
 
 	# Use CACHE_MODE_REPLACE to ensure we load the freshly saved texture,

--- a/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
+++ b/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
@@ -13,7 +13,7 @@ func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictio
 		texture = ResourceLoader.load(sprite_sheet)
 
 	if not data.is_ok:
-		printerr("Failed to load aseprite source %s" % source_file)
+		logger.error("Failed to load aseprite source", source_file)
 		return
 
 	if options.slice == "":

--- a/addons/AsepriteWizard/export/export_plugin.gd
+++ b/addons/AsepriteWizard/export/export_plugin.gd
@@ -3,6 +3,7 @@
 ## potentially leak information about paths in the host system.
 extends EditorExportPlugin
 
+const logger = preload("../config/logger.gd")
 const wizard_config = preload("../config/wizard_config.gd")
 
 func _get_name():
@@ -37,13 +38,13 @@ func _cleanup_scene(path: String, type: String):
 	if scene_changed:
 		var filtered_scene := PackedScene.new()
 		if filtered_scene.pack(root_node) != OK:
-			print("Error updating scene")
+			logger.warn("Error updating scene", path)
 			return
 
 		var content := _get_scene_content(path, filtered_scene)
 
 		if content.is_empty():
-			print("Aseprite Wizard: skipping metadata removal for ", path)
+			logger.info("No scene content. Skipping metadata removal", path)
 			return
 
 		add_file(path, content, true)
@@ -64,7 +65,7 @@ func _get_scene_content(path:String, scene:PackedScene) -> PackedByteArray:
 	var result = ResourceSaver.save(scene, tmp_path)
 
 	if result != OK:
-		print("Aseprite Wizard: could not save temporary file for ", path, ". Error ", result)
+		logger.warn("Could not save temporary file. Error: %s" % result, path)
 		return PackedByteArray()
 
 	var tmp_file = FileAccess.open(tmp_path, FileAccess.READ)

--- a/addons/AsepriteWizard/export/export_plugin.gd
+++ b/addons/AsepriteWizard/export/export_plugin.gd
@@ -96,6 +96,12 @@ func _import_extra_textures(node: SpriteFrames):
 			var tex = atlas.atlas
 			if tex == null:
 				continue
+
+			# if resource path ends with it's scene id, it's because
+			# it's embedded to scene and not an external resource
+			if tex.resource_scene_unique_id && tex.resource_path.ends_with(tex.resource_scene_unique_id):
+				continue
+		
 			if not textures.has(tex.resource_path):
 				textures.push_back(tex.resource_path)
 
@@ -114,7 +120,7 @@ func _handle_spriteframes(path: String, type: String):
 
 
 func _create_temp_resource(path: String, resource: SpriteFrames) -> PackedByteArray:
-	var tmp_path = OS.get_cache_dir() + "tmp_spriteframes_resource." + path.get_extension()
+	var tmp_path = OS.get_cache_dir().path_join("tmp_spriteframes_resource." + path.get_extension())
 	ResourceSaver.save(resource, tmp_path)
 
 	var tmp_file = FileAccess.open(tmp_path, FileAccess.READ)

--- a/addons/AsepriteWizard/files/file_lifecycle_listeners.gd
+++ b/addons/AsepriteWizard/files/file_lifecycle_listeners.gd
@@ -1,0 +1,51 @@
+@tool
+extends RefCounted
+
+const result_codes = preload("../config/result_codes.gd")
+const logger = preload("../config/logger.gd")
+var bakery = preload("../importers/helpers/bakery.gd").new()
+
+const ase_file_extensions = ["aseprite", "ase"]
+
+func setup_listeners() -> void:
+	var file_sytem_dock = EditorInterface.get_file_system_dock()
+	file_sytem_dock.file_removed.connect(_on_file_removed)
+	file_sytem_dock.files_moved.connect(_on_file_moved)
+
+
+func remove_listeners() -> void:
+	var file_sytem_dock = EditorInterface.get_file_system_dock()
+	if file_sytem_dock.file_removed.is_connected(_on_file_removed):
+		file_sytem_dock.file_removed.disconnect(_on_file_removed)
+		file_sytem_dock.files_moved.disconnect(_on_file_moved)
+
+
+func _on_file_removed(file: String) -> void:
+	var ext = file.get_extension()
+	
+	if not ase_file_extensions.has(ext):
+		return
+	
+	if bakery.has_bake_file(file):
+		var result = bakery.delete_bake_file(file)
+
+		if result != OK:
+			logger.warn(
+				"Failed to delete bake file: " + result_codes.get_error_message(result),
+				file
+			)
+
+
+func _on_file_moved(old_file: String, new_file: String) -> void:
+	var ext = old_file.get_extension()
+	
+	if not ase_file_extensions.has(ext):
+		return
+		
+	if bakery.has_bake_file(old_file):
+		var result = bakery.move_bake_file(old_file, new_file)
+		if result != OK:
+			logger.warn(
+				"Failed to move bake file: " + result_codes.get_error_message(result),
+				old_file
+			)

--- a/addons/AsepriteWizard/files/file_lifecycle_listeners.gd.uid
+++ b/addons/AsepriteWizard/files/file_lifecycle_listeners.gd.uid
@@ -1,0 +1,1 @@
+uid://dojly644meuc0

--- a/addons/AsepriteWizard/importers/helpers/bakery.gd
+++ b/addons/AsepriteWizard/importers/helpers/bakery.gd
@@ -53,6 +53,17 @@ func load_bake_texture(source_path: String, target_path: String) -> int:
 	return result
 
 
+func delete_bake_file(source_path: String) -> int:
+	return DirAccess.remove_absolute(_bake_path(source_path))
+
+
+func move_bake_file(old_path: String, new_path: String) -> int:
+	var old_bake_path = _bake_path(old_path)
+	var new_bake_path = _bake_path(new_path)
+
+	return DirAccess.rename_absolute(old_bake_path, new_bake_path)
+
+
 func _bake_path(source_path: String) -> String:
 	var file = source_path.get_file()
 	var dir = source_path.get_base_dir()

--- a/addons/AsepriteWizard/importers/helpers/bakery.gd
+++ b/addons/AsepriteWizard/importers/helpers/bakery.gd
@@ -1,0 +1,54 @@
+@tool
+extends RefCounted
+
+func save_bake_file(source_path: String, resource: Resource) -> int:
+	var bake_path = _bake_path(source_path)
+	var hash = FileAccess.get_md5(source_path)
+
+	resource.set_meta('source_hash', hash)
+
+	var result = ResourceSaver.save(resource, bake_path)
+	ResourceLoader.load(bake_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	return result
+
+
+func has_bake_file(source_path: String) -> bool:
+	var bake_path = _bake_path(source_path)
+	return ResourceLoader.exists(bake_path)
+
+
+func load_bake_file(source_path: String, target_path: String) -> int:
+	var source_hash = FileAccess.get_md5(source_path)
+	var bake_path = _bake_path(source_path)
+	var bake = ResourceLoader.load(bake_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	if bake.get_meta('source_hash') != source_hash:
+		print("Aseprite WARNING: baked file hash does not match current source file")
+
+	var result = ResourceSaver.save(bake, target_path)
+
+	ResourceLoader.load(target_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	return result
+
+
+func load_bake_texture(source_path: String, target_path: String) -> int:
+	var source_hash = FileAccess.get_md5(source_path)
+	var bake_path = _bake_path(source_path)
+	var bake: PortableCompressedTexture2D = ResourceLoader.load(bake_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	if bake.get_meta('source_hash') != source_hash:
+		print("Aseprite WARNING: baked file hash does not match current source file")
+
+	var tex := PortableCompressedTexture2D.new()
+	tex.create_from_image(bake.get_image(), PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+
+	var result = ResourceSaver.save(tex, target_path)
+	ResourceLoader.load(target_path, "PortableCompressedTexture2D", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	return result
+
+
+func _bake_path(source_path: String) -> String:
+	return "%s.ase_bake.res" % source_path

--- a/addons/AsepriteWizard/importers/helpers/bakery.gd
+++ b/addons/AsepriteWizard/importers/helpers/bakery.gd
@@ -1,6 +1,9 @@
 @tool
 extends RefCounted
 
+const logger = preload("../../config/logger.gd")
+
+
 func save_bake_file(source_path: String, resource: Resource) -> int:
 	var bake_path = _bake_path(source_path)
 	var hash = FileAccess.get_md5(source_path)
@@ -24,7 +27,7 @@ func load_bake_file(source_path: String, target_path: String) -> int:
 	var bake = ResourceLoader.load(bake_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
 
 	if bake.get_meta('source_hash') != source_hash:
-		print("Aseprite WARNING: baked file hash does not match current source file")
+		logger.warn("baked file hash does not match current source file", source_path)
 
 	var result = ResourceSaver.save(bake, target_path)
 
@@ -39,7 +42,8 @@ func load_bake_texture(source_path: String, target_path: String) -> int:
 	var bake: PortableCompressedTexture2D = ResourceLoader.load(bake_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
 
 	if bake.get_meta('source_hash') != source_hash:
-		print("Aseprite WARNING: baked file hash does not match current source file")
+		logger.warn("baked file hash does not match current source file", source_path)
+
 
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(bake.get_image(), PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)

--- a/addons/AsepriteWizard/importers/helpers/bakery.gd
+++ b/addons/AsepriteWizard/importers/helpers/bakery.gd
@@ -3,7 +3,6 @@ extends RefCounted
 
 const logger = preload("../../config/logger.gd")
 
-
 func save_bake_file(source_path: String, resource: Resource) -> int:
 	var bake_path = _bake_path(source_path)
 	var hash = FileAccess.get_md5(source_path)
@@ -55,4 +54,6 @@ func load_bake_texture(source_path: String, target_path: String) -> int:
 
 
 func _bake_path(source_path: String) -> String:
-	return "%s.ase_bake.res" % source_path
+	var file = source_path.get_file()
+	var dir = source_path.get_base_dir()
+	return dir.path_join(".%s.ase_bake.res" % file)

--- a/addons/AsepriteWizard/importers/helpers/bakery.gd.uid
+++ b/addons/AsepriteWizard/importers/helpers/bakery.gd.uid
@@ -1,0 +1,1 @@
+uid://crehekgicyf6e

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -2,6 +2,7 @@
 extends EditorImportPlugin
 
 const result_codes = preload("../config/result_codes.gd")
+const logger = preload("../config/logger.gd")
 
 var config = preload("../config/config.gd").new()
 var _aseprite = preload("../aseprite/aseprite.gd").new()
@@ -46,7 +47,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if not _aseprite.test_command():
 		if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
-			print("Aseprite command failed. Falling back to baked file. No changes will be made to children resources")
+			logger.warn("Aseprite command failed. Falling back to baked file. No changes will be made to children resources", source_file)
 			return _bakery.load_bake_file(source_file, "%s.%s" % [save_path, _get_save_extension()])
 		else:
 			return ERR_UNCONFIGURED
@@ -105,7 +106,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	if config.should_generate_bake_files():
 		var bake_code = _bakery.save_bake_file(source_file, packed)
 		if bake_code != OK:
-			printerr('ERROR - bake file creation failed ', bake_code)
+			logger.error('Bake file creation failed (%s) ' % bake_code, source_file)
 
 	_cleanup_old_layers(old_data, layers)
 

--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -5,6 +5,7 @@ const result_codes = preload("../config/result_codes.gd")
 
 var config = preload("../config/config.gd").new()
 var _aseprite = preload("../aseprite/aseprite.gd").new()
+var _bakery = preload("./helpers/bakery.gd").new()
 
 var file_system_helper
 
@@ -42,6 +43,14 @@ func _get_option_visibility(path, option, options):
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
 	var old_data = _load_old_data(source_file)
+
+	if not _aseprite.test_command():
+		if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
+			print("Aseprite command failed. Falling back to baked file. No changes will be made to children resources")
+			return _bakery.load_bake_file(source_file, "%s.%s" % [save_path, _get_save_extension()])
+		else:
+			return ERR_UNCONFIGURED
+
 	var exception_pattern = options.get('layer/exclude_layers_pattern', "")
 	var should_include_only_visibles = options.get('layer/only_visible_layers', false)
 	var should_merge_duplicates = options.get('layer/merge_duplicate_layers', false)
@@ -92,6 +101,11 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	packed.pack(data_to_save)
 
 	var exit_code = ResourceSaver.save(packed, "%s.%s" % [save_path, _get_save_extension()])
+
+	if config.should_generate_bake_files():
+		var bake_code = _bakery.save_bake_file(source_file, packed)
+		if bake_code != OK:
+			printerr('ERROR - bake file creation failed ', bake_code)
 
 	_cleanup_old_layers(old_data, layers)
 

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -6,6 +6,7 @@ const result_codes = preload("../../config/result_codes.gd")
 var config = preload("../../config/config.gd").new()
 var _aseprite = preload("../../aseprite/aseprite.gd").new()
 var _sf_creator = preload("../../creators/sprite_frames/sprite_frames_creator.gd").new()
+var _bakery = preload("../helpers/bakery.gd").new()
 
 
 func _get_importer_name():
@@ -53,6 +54,16 @@ func _get_option_visibility(path, option, options):
 
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
+	var resource_path = "%s.res" % save_path
+	var is_baking_enabled = config.should_generate_bake_files()
+
+	if not _aseprite.test_command():
+		if is_baking_enabled && _bakery.has_bake_file(source_file):
+			print("Aseprite command failed. Falling back to baked file...")
+			return _bakery.load_bake_file(source_file, resource_path)
+		else:
+			return ERR_UNCONFIGURED
+
 	var file = FileAccess.open(source_file, FileAccess.READ)
 	var data = JSON.parse_string(file.get_as_text())
 
@@ -82,7 +93,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resources = _sf_creator.create_resources([source_files], {
 		"should_round_fps": data.import_options.should_round_fps,
 		"should_create_portable_texture": true,
-		"sheet_base_path": save_path,
+		#"sheet_base_path": save_path,
 	})
 
 	if not resources.is_ok:
@@ -92,11 +103,14 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resource = resources.content[0]
 	resource.resource.set_meta("imported_via_aw", true)
 
-	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)
 	ResourceLoader.load(resource_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
 
+	if is_baking_enabled:
+		var bake_code = _bakery.save_bake_file(source_file, resource.resource)
+		if bake_code != OK:
+			printerr('ERROR - bake file creation failed ', bake_code)
 
 	for extra_file in resource.extra_gen_files:
 		gen_files.push_back(extra_file)

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_import_plugin.gd
@@ -2,6 +2,7 @@
 extends EditorImportPlugin
 
 const result_codes = preload("../../config/result_codes.gd")
+const logger = preload("../../config/logger.gd")
 
 var config = preload("../../config/config.gd").new()
 var _aseprite = preload("../../aseprite/aseprite.gd").new()
@@ -59,7 +60,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if not _aseprite.test_command():
 		if is_baking_enabled && _bakery.has_bake_file(source_file):
-			print("Aseprite command failed. Falling back to baked file...")
+			logger.warn("Aseprite command failed. Falling back to baked file...")
 			return _bakery.load_bake_file(source_file, resource_path)
 		else:
 			return ERR_UNCONFIGURED
@@ -87,17 +88,16 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	)
 
 	if source_files.is_empty():
-		printerr("ERROR - Could not import aseprite file. Layer not found.")
+		logger.error("Could not import aseprite file. Layer not found.", source_file)
 		return FAILED
 #
 	var resources = _sf_creator.create_resources([source_files], {
 		"should_round_fps": data.import_options.should_round_fps,
 		"should_create_portable_texture": true,
-		#"sheet_base_path": save_path,
 	})
 
 	if not resources.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
+		logger.error("Could not import aseprite file: %s" % result_codes.get_error_message(resources.code), source_file)
 		return FAILED
 
 	var resource = resources.content[0]
@@ -110,7 +110,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	if is_baking_enabled:
 		var bake_code = _bakery.save_bake_file(source_file, resource.resource)
 		if bake_code != OK:
-			printerr('ERROR - bake file creation failed ', bake_code)
+			logger.error('Bake file creation failed (%s) ' % bake_code, source_file)
 
 	for extra_file in resource.extra_gen_files:
 		gen_files.push_back(extra_file)
@@ -119,7 +119,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		_remove_source_files(source_files)
 
 	if exit_code != OK:
-		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		logger.error("Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code), source_file)
 		return FAILED
 
 	return OK

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
@@ -27,6 +27,11 @@ func _get_import_options(_path, _i):
 
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
+	var bake_result = _handle_bake_fallback(source_file, save_path)
+
+	if bake_result != CONTINUE_STATUS_CODE:
+		return bake_result
+
 	var file = FileAccess.open(source_file, FileAccess.READ)
 	var i_data = JSON.parse_string(file.get_as_text())
 
@@ -51,4 +56,4 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	return _save_resource(sprite_sheet, save_path, result.content.data_file, data.meta.size)
+	return _save_resource(source_file, sprite_sheet, save_path, result.content.data_file, data.meta.size)

--- a/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/split_layer_importers/layer_texture_import_plugin.gd
@@ -50,7 +50,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var result = _generate_texture(absolute_source_file, aseprite_opts)
 
 	if not result.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(result.code))
+		logger.error("Could not import aseprite file: %s" % result_codes.get_error_message(result.code), source_file)
 		return FAILED
 
 	var sprite_sheet = result.content.sprite_sheet

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -6,6 +6,7 @@ const result_codes = preload("../config/result_codes.gd")
 var config = preload("../config/config.gd").new()
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
+var _bakery = preload("./helpers/bakery.gd").new()
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
 
 
@@ -76,6 +77,16 @@ func _get_option_visibility(path, option, options):
 
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
+	var resource_path = "%s.res" % save_path
+	var is_baking_enabled = config.should_generate_bake_files()
+
+	if not _aseprite_file_exporter.is_aseprite_command_working():
+		if is_baking_enabled && _bakery.has_bake_file(source_file):
+			print("Aseprite command failed. Falling back to baked file...")
+			return _bakery.load_bake_file(source_file, resource_path)
+		else:
+			return ERR_UNCONFIGURED
+
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
 
@@ -103,7 +114,6 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resources = _sf_creator.create_resources(source_files.content, {
 		"should_round_fps": options["animation/round_fps"],
 		"should_create_portable_texture": true,
-		"sheet_base_path": save_path,
 	})
 
 	if not resources.is_ok:
@@ -112,10 +122,15 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	var resource: Dictionary = resources.content[0]
 	resource.resource.set_meta("imported_via_aw", true)
-	var resource_path = "%s.res" % save_path
 	var exit_code = ResourceSaver.save(resource.resource, resource_path)
 	resource.resource.take_over_path(resource_path)
 	ResourceLoader.load(resource_path, "", ResourceLoader.CACHE_MODE_REPLACE_DEEP)
+
+	if is_baking_enabled:
+		var bake_code = _bakery.save_bake_file(source_file, resource.resource)
+		if bake_code != OK:
+			printerr('ERROR - bake file creation failed ', bake_code)
+
 
 	if config.should_remove_source_files():
 		_remove_source_files(source_files.content)

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -2,6 +2,7 @@
 extends EditorImportPlugin
 
 const result_codes = preload("../config/result_codes.gd")
+const logger = preload("../config/logger.gd")
 
 var config = preload("../config/config.gd").new()
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
@@ -82,7 +83,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if not _aseprite_file_exporter.is_aseprite_command_working():
 		if is_baking_enabled && _bakery.has_bake_file(source_file):
-			print("Aseprite command failed. Falling back to baked file...")
+			logger.warn("Aseprite command failed. Falling back to baked file...", source_file)
 			return _bakery.load_bake_file(source_file, resource_path)
 		else:
 			return ERR_UNCONFIGURED
@@ -108,7 +109,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	var source_files = _aseprite_file_exporter.generate_aseprite_files(absolute_source_file, aseprite_opts)
 	if not source_files.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(source_files.code))
+		logger.error("Could not import aseprite file: %s" % result_codes.get_error_message(source_files.code), source_file)
 		return FAILED
 
 	var resources = _sf_creator.create_resources(source_files.content, {
@@ -117,7 +118,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	})
 
 	if not resources.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(resources.code))
+		logger.error("Could not import aseprite file: %s" % result_codes.get_error_message(resources.code), source_file)
 		return FAILED
 
 	var resource: Dictionary = resources.content[0]
@@ -129,14 +130,14 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	if is_baking_enabled:
 		var bake_code = _bakery.save_bake_file(source_file, resource.resource)
 		if bake_code != OK:
-			printerr('ERROR - bake file creation failed ', bake_code)
+			logger.error('Bake file creation failed (%s)' % bake_code, source_file)
 
 
 	if config.should_remove_source_files():
 		_remove_source_files(source_files.content)
 
 	if exit_code != OK:
-		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		logger.error("Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code), source_file)
 		return FAILED
 
 	return OK

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -45,6 +45,11 @@ func _get_import_options(_path, _i):
 	]
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
+	var bake_result = _handle_bake_fallback(source_file, save_path)
+
+	if bake_result != CONTINUE_STATUS_CODE:
+		return bake_result
+	
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var source_path = source_file.get_base_dir()
 
@@ -71,4 +76,4 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	return _save_resource(sprite_sheet, save_path, result.content.data_file, data.meta.size)
+	return _save_resource(source_file, sprite_sheet, save_path, result.content.data_file, data.meta.size)

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -70,7 +70,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var result = _generate_texture(absolute_source_file, aseprite_opts)
 
 	if not result.is_ok:
-		printerr("ERROR - Could not import aseprite file: %s" % result_codes.get_error_message(result.code))
+		logger.error("Could not import aseprite file: %s" % result_codes.get_error_message(result.code), source_file)
 		return FAILED
 
 	var sprite_sheet = result.content.sprite_sheet

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
@@ -2,6 +2,7 @@
 extends EditorImportPlugin
 
 const result_codes = preload("../config/result_codes.gd")
+const logger = preload("../config/logger.gd")
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 var _bakery = preload("./helpers/bakery.gd").new()
 
@@ -67,13 +68,13 @@ func _save_resource(source_file: String, sprite_sheet: String, save_path: String
 		DirAccess.remove_absolute(sprite_sheet)
 
 	if exit_code != OK:
-		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		logger.error("Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code), source_file)
 		return FAILED
 
 	if config.should_generate_bake_files():
 		var bake_code = _bakery.save_bake_file(source_file, tex)
 		if bake_code != OK:
-			printerr('ERROR - bake file creation failed ', bake_code)
+			logger.error('Bake file creation failed (%s)' % bake_code, source_file)
 
 	return OK
 
@@ -83,7 +84,7 @@ func _handle_bake_fallback(source_file: String, save_path: String) -> int:
 		return CONTINUE_STATUS_CODE
 
 	if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
-		print("Aseprite command failed. Falling back to baked file (%s)" % source_file)
+		logger.warn("Aseprite command failed. Falling back to baked file", source_file)
 		var resource_path = "%s.%s" % [save_path, _get_save_extension()]
 		return _bakery.load_bake_texture(source_file, resource_path)
 	else:

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
@@ -3,9 +3,11 @@ extends EditorImportPlugin
 
 const result_codes = preload("../config/result_codes.gd")
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
+var _bakery = preload("./helpers/bakery.gd").new()
 
 var config = preload("../config/config.gd").new()
 
+const CONTINUE_STATUS_CODE = 91919
 
 func _get_save_extension():
 	return "res"
@@ -52,7 +54,7 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 	})
 
 
-func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
+func _save_resource(source_file: String, sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
 	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 
 	var tex := PortableCompressedTexture2D.new()
@@ -68,4 +70,21 @@ func _save_resource(sprite_sheet: String, save_path: String, data_file_path: Str
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
 		return FAILED
 
+	if config.should_generate_bake_files():
+		var bake_code = _bakery.save_bake_file(source_file, tex)
+		if bake_code != OK:
+			printerr('ERROR - bake file creation failed ', bake_code)
+
 	return OK
+
+
+func _handle_bake_fallback(source_file: String, save_path: String) -> int:
+	if _aseprite_file_exporter.is_aseprite_command_working():
+		return CONTINUE_STATUS_CODE
+
+	if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
+		print("Aseprite command failed. Falling back to baked file (%s)" % source_file)
+		var resource_path = "%s.%s" % [save_path, _get_save_extension()]
+		return _bakery.load_bake_texture(source_file, resource_path)
+	else:
+		return ERR_UNCONFIGURED

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -6,6 +6,9 @@ extends EditorImportPlugin
 ## Imports Aseprite tileset layers as an AtlasTexture
 ##
 
+const CONTINUE_STATUS_CODE = 91919
+
+var _bakery = preload("./helpers/bakery.gd").new()
 const result_codes = preload("../config/result_codes.gd")
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 
@@ -74,6 +77,11 @@ func _get_option_visibility(path, option, options):
 
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
+	var bake_result = _handle_bake_fallback(source_file, save_path)
+
+	if bake_result != CONTINUE_STATUS_CODE:
+		return bake_result
+
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var absolute_save_path = ProjectSettings.globalize_path(save_path)
 	var source_path = source_file.get_base_dir()
@@ -103,7 +111,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	return _save_resource(sprite_sheet, save_path, result.content.data_file, data.meta.size)
+	return _save_resource(source_file, sprite_sheet, save_path, result.content.data_file, data.meta.size)
 
 
 func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dictionary:
@@ -128,7 +136,7 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 	})
 
 
-func _save_resource(sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
+func _save_resource(source_file: String, sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
 	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 
 	var tex := PortableCompressedTexture2D.new()
@@ -144,4 +152,21 @@ func _save_resource(sprite_sheet: String, save_path: String, data_file_path: Str
 		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
 		return FAILED
 
+	if config.should_generate_bake_files():
+		var bake_code = _bakery.save_bake_file(source_file, tex)
+		if bake_code != OK:
+			printerr('ERROR - bake file creation failed ', source_file, ' ', bake_code)
+
 	return OK
+
+
+func _handle_bake_fallback(source_file: String, save_path: String) -> int:
+	if _aseprite_file_exporter.is_aseprite_command_working():
+		return CONTINUE_STATUS_CODE
+
+	if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
+		print("Aseprite command failed. Falling back to baked file (%s)" % source_file)
+		var resource_path = "%s.%s" % [save_path, _get_save_extension()]
+		return _bakery.load_bake_texture(source_file, resource_path)
+	else:
+		return ERR_UNCONFIGURED

--- a/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/tileset_texture_import_plugin.gd
@@ -8,8 +8,9 @@ extends EditorImportPlugin
 
 const CONTINUE_STATUS_CODE = 91919
 
-var _bakery = preload("./helpers/bakery.gd").new()
 const result_codes = preload("../config/result_codes.gd")
+const logger = preload("../config/logger.gd")
+var _bakery = preload("./helpers/bakery.gd").new()
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 
 var config = preload("../config/config.gd").new()
@@ -105,7 +106,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 		if result.code == result_codes.ERR_INVALID_ASEPRITE_SPRITESHEET:
 			extra_error_info = " Make sure your Aseprite file contains at least one Tilemap layer."
 
-		printerr("ERROR - Could not import aseprite file: %s.%s" % [result_codes.get_error_message(result.code), extra_error_info])
+		logger.error("Could not import aseprite file: %s.%s" % [result_codes.get_error_message(result.code), extra_error_info], source_file)
 		return FAILED
 
 	var sprite_sheet = result.content.sprite_sheet
@@ -149,13 +150,13 @@ func _save_resource(source_file: String, sprite_sheet: String, save_path: String
 		DirAccess.remove_absolute(sprite_sheet)
 
 	if exit_code != OK:
-		printerr("ERROR - Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code))
+		logger.error("Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code), source_file)
 		return FAILED
 
 	if config.should_generate_bake_files():
 		var bake_code = _bakery.save_bake_file(source_file, tex)
 		if bake_code != OK:
-			printerr('ERROR - bake file creation failed ', source_file, ' ', bake_code)
+			logger.error('Bake file creation failed (%s)' % bake_code, source_file)
 
 	return OK
 
@@ -165,7 +166,7 @@ func _handle_bake_fallback(source_file: String, save_path: String) -> int:
 		return CONTINUE_STATUS_CODE
 
 	if config.should_generate_bake_files() && _bakery.has_bake_file(source_file):
-		print("Aseprite command failed. Falling back to baked file (%s)" % source_file)
+		logger.warn("Aseprite command failed. Falling back to baked file", source_file)
 		var resource_path = "%s.%s" % [save_path, _get_save_extension()]
 		return _bakery.load_bake_texture(source_file, resource_path)
 	else:

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
@@ -42,7 +42,7 @@ func _do_import():
 
 	if not aseprite_output.is_ok:
 		var error = result_code.get_error_message(aseprite_output.code)
-		printerr(error)
+		logger.error(error, source_path)
 		_show_message(error)
 		return
 

--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -1,6 +1,7 @@
 @tool
 extends PanelContainer
 
+const logger = preload("../../config/logger.gd")
 const wizard_config = preload("../../config/wizard_config.gd")
 const result_code = preload("../../config/result_codes.gd")
 var _aseprite_file_exporter = preload("../../aseprite/file_exporter.gd").new()
@@ -488,7 +489,7 @@ func _show_message(message: String):
 
 func _notify_aseprite_error(aseprite_error_code):
 	var error = result_code.get_error_message(aseprite_error_code)
-	printerr(error)
+	logger.error(error)
 	_show_message(error)
 
 

--- a/addons/AsepriteWizard/interface/docks/wizard/imported_sprite_frames.gd
+++ b/addons/AsepriteWizard/interface/docks/wizard/imported_sprite_frames.gd
@@ -2,7 +2,7 @@
 extends PanelContainer
 
 signal import_success(fields)
-
+const logger = preload("../../../config/logger.gd")
 const result_code = preload("../../../config/result_codes.gd")
 const wizard_config = preload("../../../config/wizard_config.gd")
 var _import_helper = preload("./wizard_import_helper.gd").new()
@@ -259,16 +259,16 @@ func _do_import(resource_path: String, metadata: Dictionary) -> int:
 	var resource_base_dir = resource_path.get_base_dir()
 
 	if resource_base_dir != metadata.fields.output_location:
-		print("Resource has moved. Changing output folder from %s to %s" % [resource_base_dir, metadata.fields.output_location])
+		logger.info("Resource has moved. Changing output folder from %s to %s" % [resource_base_dir, metadata.fields.output_location])
 		metadata.fields.output_location = resource_base_dir
 
 	var exit_code := await _import_helper.import_and_create_resources(metadata.fields.source_file, metadata.fields)
 
 	if exit_code == OK:
-		print("Import complete: %s" % resource_path)
+		logger.info("Import complete: %s" % resource_path)
 		import_success.emit(metadata.fields)
 	else:
-		printerr("Failed to import %s. Error: %s" % [resource_path, result_code.get_error_message(exit_code)])
+		logger.error("Failed to import %s. Error: %s" % [resource_path, result_code.get_error_message(exit_code)])
 
 	return exit_code
 

--- a/addons/AsepriteWizard/interface/imports_manager/dock_imports_panel.gd
+++ b/addons/AsepriteWizard/interface/imports_manager/dock_imports_panel.gd
@@ -1,6 +1,7 @@
 @tool
 extends Panel
 
+const logger = preload("../../config/logger.gd")
 const wizard_config = preload("../../config/wizard_config.gd")
 
 var _import_helper = preload("./import_helper.gd").new()
@@ -167,11 +168,11 @@ func _trigger_import(meta: Dictionary) -> void:
 	var root_node = EditorInterface.get_edited_scene_root()
 
 	if not root_node:
-		printerr("couldn´t open scene %s" % meta.scene_path)
+		logger.error("Couldn't open scene", meta.scene_path)
 
 	await _import_helper.import_node(root_node, meta)
 
-	print("Import complete: %s (%s) node from %s" % [ meta.node_path, meta.meta.source, meta.scene_path])
+	logger.info("Import complete: %s (%s) node from %s" % [ meta.node_path, meta.meta.source, meta.scene_path])
 
 
 func _on_resource_tree_multi_selected(_item: TreeItem, _column: int, selected: bool) -> void:

--- a/addons/AsepriteWizard/interface/imports_manager/import_helper.gd
+++ b/addons/AsepriteWizard/interface/imports_manager/import_helper.gd
@@ -1,6 +1,7 @@
 @tool
 extends RefCounted
 
+const logger = preload("../../config/logger.gd")
 const wizard_config = preload("../../config/wizard_config.gd")
 const result_code = preload("../../config/result_codes.gd")
 
@@ -16,7 +17,7 @@ func import_node(root_node: Node, meta: Dictionary) -> void:
 	var node = root_node.get_node(meta.node_path)
 
 	if node == null:
-		printerr("Node not found: %s" % meta.node_path)
+		logger.error("Node not found: %s" % meta.node_path)
 		return
 
 	if node is AnimatedSprite2D or node is AnimatedSprite3D:
@@ -28,7 +29,7 @@ func import_node(root_node: Node, meta: Dictionary) -> void:
 func _sprite_frames_import(node: Node, resource_config: Dictionary) -> void:
 	var config = resource_config.meta
 	if not config.source:
-		printerr("Node config missing information.")
+		logger.error("Node config missing information.")
 		return
 
 	var source = ProjectSettings.globalize_path(_get_updated_source_path(config))
@@ -37,7 +38,7 @@ func _sprite_frames_import(node: Node, resource_config: Dictionary) -> void:
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source, options)
 
 	if not aseprite_output.is_ok:
-		printerr(result_code.get_error_message(aseprite_output.code))
+		logger.error(result_code.get_error_message(aseprite_output.code))
 		return
 
 	EditorInterface.get_resource_filesystem().scan()
@@ -56,7 +57,7 @@ func _sprite_frames_import(node: Node, resource_config: Dictionary) -> void:
 
 func _animation_import(node: Node, root_node: Node, resource_config: Dictionary) -> void:
 	if not resource_config.meta.source:
-		printerr("Node config missing information.")
+		logger.error("Node config missing information.")
 		return
 
 	if resource_config.meta.get("i_mode", 0) == 0:
@@ -72,7 +73,7 @@ func _import_to_animation_player(node: Node, root: Node, resource_config: Dictio
 
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source, options)
 	if not aseprite_output.is_ok:
-		printerr(result_code.get_error_message(aseprite_output.code))
+		logger.error(result_code.get_error_message(aseprite_output.code))
 		return
 
 	EditorInterface.get_resource_filesystem().scan()
@@ -101,7 +102,7 @@ func _import_static(node: Node, resource_config: Dictionary) -> void:
 	var aseprite_output = _aseprite_file_exporter.generate_aseprite_file(source, options)
 
 	if not aseprite_output.is_ok:
-		printerr(result_code.get_error_message(aseprite_output.code))
+		logger.error(result_code.get_error_message(aseprite_output.code))
 		return
 
 	EditorInterface.get_resource_filesystem().scan()

--- a/addons/AsepriteWizard/plugin.gd
+++ b/addons/AsepriteWizard/plugin.gd
@@ -27,6 +27,7 @@ const menu_item_name = "Spritesheet Wizard Dock..."
 const config_menu_item_name = "Config..."
 const import_menu_item_name = "Imports Manager..."
 
+var file_lifecycle_listeners = preload("files/file_lifecycle_listeners.gd").new()
 var config = preload("config/config.gd").new()
 var window: TabContainer
 var config_window: Window
@@ -49,6 +50,7 @@ func _enter_tree():
 	_setup_exporter()
 	_setup_animated_sprite_inspector_plugin()
 	_setup_sprite_inspector_plugin()
+	_setup_file_listeners()
 
 
 func _exit_tree():
@@ -61,6 +63,7 @@ func _disable_plugin():
 	_remove_exporter()
 	_remove_wizard_dock()
 	_remove_inspector_plugins()
+	_remove_file_listeners()
 
 
 func _load_config():
@@ -217,3 +220,11 @@ func _create_imports_manager_window(panel: MarginContainer):
 	imports_list_window.add_child(panel)
 	get_editor_interface().get_base_control().add_child(imports_list_window)
 	imports_list_window.popup_centered_ratio(0.5)
+
+
+func _setup_file_listeners() -> void:
+	file_lifecycle_listeners.setup_listeners()
+
+
+func _remove_file_listeners() -> void:
+	file_lifecycle_listeners.remove_listeners()


### PR DESCRIPTION
This PR implements "bake files", as suggested on #178 .

## Context

This plugin has a few different methods to import Aseprite files to Godot. Automatic importing is likely the most popular
as this is how Godot's native importing works.

With the importers you can use Aseprite files directly as SpriteFrames or Texture resources. Any changes in the source Aseprite file triggers a re-import, so you are always dealing with the most up-to-date version.

The downside is that the importer needs the Aseprite binary to generate the target files. This means that you either have to install Aseprite on every machine running your project (including CI), or commit the project's `.godot/imports` folder to your version control, which is not ideal.

Currently, your options are:

- Make sure Aseprite is available on every machine running your project. Not ideal for continuous integration/deployment due to the Aseprite's license. You are only allowed to do this if compiling from source, which might take a long time and make your builds more fragile and wasteful.
- Include `.godot/imports` to your source control. As mentioned, this is not ideal as it can bloat your history.
- Use the Inspector dock method. The plugin has other import methods which give more control to when import the files, but require extra manual management. Not really a replacement for automated imports.

## The proposed solution

This PR introduces a new project settings "Generate bake files" (disabled by default). This option creates a `.*.ase_bake.res` file alongside your source file. This file is a copy of the generate assets and should be include in the version control.

When importing your project in a machine without Aseprite installed, the importer will look for the bake file and use it if available instead of failing the import.

A few things to consider:

- As expected, the bake files should be included in the version control. This is slightly equivalent to including the content of `.godot/imports`, but it does not require any extra configuration and it's focused on the pixel art files, which are usually small.
- On import, the importer will print warnings when falling back to a bake file, and when the bake file does not match the current source file. These are there so the developer is aware the fallback is happening in case it's just a misconfiguration.
- The bake files are saved with a `.` in front of the filename. This is done for a few reasons:
	- They are hidden from the file system dock, making less noise
	- Hiding discourage using them directly. For flexibility, you should always reference the `*.aseprite` files, so you can enable/disable bake files as you wish
	- By default, files starting with `.` are not included when exporting your game. These bake files are duplicates from the ones in the import folder, and only one copy should be included in the exported project to save space.

## Progress

- [x] Change importers to generate bake files and use them as fallback
- [x] "Generate bake files" project settings
- [x] Move bake file when source file is moved
- [x] Remove bake file when source file is removed
- [x] Test it on Linux
- [x] Test it on MacOS
- [x] Test it on Windows

### Unrelated changes

- Fix export plugin scene temporary path built incorrectly #246
- Improve logs. Centralize logging and make sure file path is included when relevant
- Changed custom error codes so they don't conflict with internal engine errors.


### Internal changes
- SpriteFrames textures are embedded to simplify bake files. This was already an option in other methods. There is no functional difference.
- Importers check if Aseprite command is configured correctly before trying the actual import.

### Known existing issues not related to these changes

- I noticed that when using split imports, the child resources are not automatically reimported when the source changes. Not sure if this happens all the time, but I will deal with it in another PR. (fixed on https://github.com/viniciusgerevini/godot-aseprite-wizard/pull/249)