### PR TITLE
Fix empty textures generated on split layer reimport

### DIFF
--- a/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
+++ b/addons/AsepriteWizard/creators/base_sprite_resource_creator.gd
@@ -9,7 +9,11 @@ var _config = preload("../config/config.gd").new()
 
 
 func _load_compressed_texture(sprite_sheet: String) -> PortableCompressedTexture2D:
-	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
+	var global_path = ProjectSettings.globalize_path(sprite_sheet)
+	var image = Image.load_from_file(global_path)
+	if image == null or image.is_empty():
+		printerr("ERROR - Failed to load sprite sheet image: %s (resolved to: %s)" % [sprite_sheet, global_path])
+		return null
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
 	return tex

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -69,6 +69,9 @@ func _load_aseprite_resources(aseprite_data: Dictionary, options: Dictionary) ->
 
 	var result = _load_or_create_texture_resource(aseprite_data.sprite_sheet, options)
 
+	if result.get("error", false):
+		return result_code.error(result_code.ERR_ASEPRITE_EXPORT_FAILED)
+
 	return result_code.result({
 		"metadata": content_result.content,
 		"texture": result.texture,
@@ -78,18 +81,24 @@ func _load_aseprite_resources(aseprite_data: Dictionary, options: Dictionary) ->
 
 func _load_or_create_texture_resource(sprite_sheet: String, options: Dictionary) -> Dictionary:
 	if not options.get("should_create_portable_texture", false):
-		return { "texture": _load_texture(sprite_sheet), "extra_gen_files": [] }
+		var tex = _load_texture(sprite_sheet)
+		if tex == null:
+			return { "texture": null, "error": true, "extra_gen_files": [] }
+		return { "texture": tex, "extra_gen_files": [] }
 
 	if options.get("sheet_base_path", "") == "":
-		return {
-			"texture": create_packed_texture(sprite_sheet),
-			"extra_gen_files": []
-		}
+		var tex = create_packed_texture(sprite_sheet)
+		if tex == null:
+			return { "texture": null, "error": true, "extra_gen_files": [] }
+		return { "texture": tex, "extra_gen_files": [] }
 
 	var texture_path = "%s.%s.texture.res" % [options.sheet_base_path, sprite_sheet.get_file().get_basename() ]
+	var tex = create_packed_texture(sprite_sheet, texture_path)
+	if tex == null:
+		return { "texture": null, "error": true, "extra_gen_files": [texture_path] }
 
 	return {
-		"texture": create_packed_texture(sprite_sheet, texture_path),
+		"texture": tex,
 		"extra_gen_files": [texture_path]
 	}
 
@@ -214,6 +223,8 @@ func _load_texture(path) -> CompressedTexture2D:
 
 func create_packed_texture(sprite_sheet: String, save_path: String = "") -> PortableCompressedTexture2D:
 	var tex := _load_compressed_texture(sprite_sheet)
+	if tex == null:
+		return null
 	# if no path was provided, we just want the texture in memory
 	if save_path == "":
 		return tex
@@ -223,7 +234,9 @@ func create_packed_texture(sprite_sheet: String, save_path: String = "") -> Port
 		printerr(result_code.get_error_message(result_code.ERR_ASEPRITE_EXPORT_FAILED))
 		return null
 
-	return ResourceLoader.load(save_path)
+	# Use CACHE_MODE_REPLACE to ensure we load the freshly saved texture,
+	# not a stale cached version from a previous import
+	return ResourceLoader.load(save_path, "", ResourceLoader.CACHE_MODE_REPLACE)
 
 
 func _add_to_sprite_frames(


### PR DESCRIPTION
## Problem

When reimporting split layers (especially with complex layer hierarchies), textures would sometimes be saved as essentially empty files (~290 bytes) instead of containing the actual sprite data. The PNG export from Aseprite was working fine, but the resulting `.texture.res` files were broken.

This was pretty frustrating to debug since there were no error messages - imports would "succeed" but the sprites would just be invisible in-game.

## Root Cause

Two issues were contributing to this:

1. `_load_compressed_texture()` didn't check if `Image.load_from_file()` actually succeeded. If the image failed to load for any reason, it would just create an empty `PortableCompressedTexture2D` and carry on.

2. When saving and reloading the texture in `create_packed_texture()`, the default cache mode was being used. This could return a stale cached version instead of the freshly written file.

## Fix

- Added validation after `Image.load_from_file()` to catch failures early and log a helpful error message with both the original and resolved paths
- Propagated texture loading errors up through `_load_or_create_texture_resource()` so imports fail properly instead of silently creating broken resources  
- Changed `ResourceLoader.load()` to use `CACHE_MODE_REPLACE` to ensure we always get the fresh texture

## Testing

Tested with a complex split layer setup (player character with 15+ layers in nested groups). Before the fix, reimports would consistently produce empty textures. After the fix, reimports work reliably.