### PR TITLE
Support split layers in texture importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Frame padding and sheet type options to Texture split importer
+- Texture split importer: added frame padding and sheet type options
+- Texture importer: added split layers option
+
+### Thanks
+
+- @snorthman for sheet type feature request
+- @janos-ijgyarto for split layers feature request
 
 ## 9.7.0 (2026-02-18)
 

--- a/addons/AsepriteWizard/aseprite/aseprite.gd
+++ b/addons/AsepriteWizard/aseprite/aseprite.gd
@@ -34,6 +34,9 @@ func export_file(file_name: String, output_folder: String, options: Dictionary) 
 		arguments.push_front("'[0, 0]'")
 		arguments.push_front("--frame-range")
 
+	if options.get('split_layers', false):
+		arguments.push_front("--split-layers")
+
 	_add_sheet_type_arguments(arguments, options)
 
 	_add_ignore_layer_arguments(file_name, arguments, exception_pattern)
@@ -96,6 +99,9 @@ func export_file_with_layers(file_name: String, layer_names: Array, output_folde
 	if first_frame_only:
 		arguments.push_front("'[0, 0]'")
 		arguments.push_front("--frame-range")
+
+	if options.get('split_layers', false):
+		arguments.push_front("--split-layers")
 
 	_add_sheet_type_arguments(arguments, options)
 

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -27,6 +27,7 @@ func _get_import_options(_path, _i):
 	return [
 		{"name": "layer/exclude_layers_pattern", "default_value": config.get_default_exclusion_pattern()},
 		{"name": "layer/only_visible_layers", "default_value": false},
+		{"name": "layer/split_layers", "default_value": false},
 		{"name": "first_frame_only", "default_value": true},
 		{
 			"name": "sheet/sheet_type",
@@ -56,6 +57,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var aseprite_opts = {
 		"exception_pattern": options['layer/exclude_layers_pattern'],
 		"only_visible_layers": options['layer/only_visible_layers'],
+		"split_layers": options.get('layer/split_layers', false),
 		"output_filename": '',
 		"output_folder": source_path,
 		"scale": str(options["sheet/scale"]),


### PR DESCRIPTION
#217 

Split layers false:
<img width="258" height="59" alt="Screenshot 2026-02-21 at 19 58 16" src="https://github.com/user-attachments/assets/db727f27-7d03-4fc0-81f5-65229b33ad4e" />
Split layers true (column mode):
<img width="264" height="168" alt="Screenshot 2026-02-21 at 19 58 04" src="https://github.com/user-attachments/assets/18690ddf-02c3-4a11-a150-d7b3951e0765" />
