### PR TITLE
Fixed recursive loop when initially importing file

### DIFF
--- a/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/multiple_import_plugin_base.gd
@@ -125,8 +125,20 @@ func _get_base_import_options(options: Dictionary):
 func _load_old_data(source_file: String):
 	var old_data = {}
 
-	if ResourceLoader.exists(source_file):
-		var d = ResourceLoader.load(source_file)
+	var import_path = source_file + ".import"
+	if not FileAccess.file_exists(import_path):
+		return old_data
+
+	var cfg = ConfigFile.new()
+	if cfg.load(import_path) != OK:
+		return old_data
+
+	var dest_path = cfg.get_value("remap", "path", "")
+	if dest_path == "" or not FileAccess.file_exists(dest_path):
+		return old_data
+
+	if ResourceLoader.exists(dest_path):
+		var d = ResourceLoader.load(dest_path)
 		# handling JSON to keep it backwards compatible
 		# remove it in the next major version
 		if d is JSON:


### PR DESCRIPTION
Found an issue with the _load_old_data function when the .godot directory hasn't been generated yet. The ResourceLoader says the resource exists (because it's mid-import), but when it tries to do so, it just recursively loops against itself. 

```
ERROR: Error loading resource: 'res://UI/BaseUI/Cell/Cell.aseprite'.
   at: load (core/core_bind.cpp:74)
   GDScript backtrace (most recent call first):
       [0] _load_old_data (res://addons/AsepriteWizard/importers/multiple_import_plugin_base.gd:129)
       [1] _import (res://addons/AsepriteWizard/importers/multiple_import_plugin_base.gd:46)
       [2] _load_old_data (res://addons/AsepriteWizard/importers/multiple_import_plugin_base.gd:129)
       [3] _import (res://addons/AsepriteWizard/importers/multiple_import_plugin_base.gd:46)
```

Just changed the function to load the resource file directly from the .godot directory based on what it finds in the `.aseprite.import` file. Looks to be working now!