### PR TITLE
CPU-based normal map generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ _Check the screenshots folder for more examples._
 - Separates each Aseprite Tag into animations. In case no tags are defined, imports everything as default animation.
 - Filters out layers you don't want in the final animation using regex.
 - Supports slices. Import only a region from your file.
+- **Normal Map generation**: CPU-based normal map generator, no external tools required.
+  - Generates a `_n.png` normal map from the diffuse sprite sheet using distance field + emboss techniques.
+  - Configurable parameters: Emboss Height, Bump Height, Blur, and Bump intensity.
+  - Wraps diffuse and normal textures in a `CanvasTexture` automatically.
+  - Two independent embed controls in the Output section:
+    - **Embed Texture**: when ON, textures are stored as `PortableCompressedTexture2D` data; when OFF, PNG files are created on disk and referenced.
+    - **Embed Resource**: when ON, the `CanvasTexture` (or plain texture) is inlined in the scene; when OFF, a `.tres` file is saved on disk and referenced.
+  - Works with AnimationPlayer, AnimatedSprite2D/3D, and static Sprite/TextureRect imports.
 - For AnimatedSprite
   - Creates SpriteFrames with Atlas Texture to be used in AnimatedSprites.
   - Converts Aseprite frame duration (defined in milliseconds) to Godot's animation FPS. This way you can create your animation with the right timing in Aseprite and it should work the same way in Godot.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ _Check the screenshots folder for more examples._
   - Generates a `_n.png` normal map from the diffuse sprite sheet using distance field + emboss techniques.
   - Configurable parameters: Emboss Height, Bump Height, Blur, and Bump intensity.
   - Wraps diffuse and normal textures in a `CanvasTexture` automatically.
+  - Generation runs in a **background thread** — the editor stays responsive even for large sprite sheets.
   - Two independent embed controls in the Output section:
     - **Embed Texture**: when ON, textures are stored as `PortableCompressedTexture2D` data; when OFF, PNG files are created on disk and referenced.
     - **Embed Resource**: when ON, the `CanvasTexture` (or plain texture) is inlined in the scene; when OFF, a `.tres` file is saved on disk and referenced.

--- a/addons/AsepriteWizard/config/config.gd
+++ b/addons/AsepriteWizard/config/config.gd
@@ -31,6 +31,13 @@ const IMPORTER_STATIC_TEXTURE_SPLIT_NAME = "Static Texture (Split By Layer)"
 
 const _IMPORTER_GENERATE_BAKE_FILE_KEY = 'aseprite/import/import_plugin/generate_bake_files'
 
+# normal map generation
+const _NORMALMAP_ENABLED_KEY = 'aseprite/normalmap/enabled'
+const _NORMALMAP_EMBOSS_HEIGHT_KEY = 'aseprite/normalmap/emboss_height'
+const _NORMALMAP_BUMP_HEIGHT_KEY = 'aseprite/normalmap/bump_height'
+const _NORMALMAP_BLUR_KEY = 'aseprite/normalmap/blur'
+const _NORMALMAP_BUMP_KEY = 'aseprite/normalmap/bump'
+
 # wizard history
 const _WIZARD_HISTORY = "wizard_history"
 const _HISTORY_MAX_ENTRIES = 'aseprite/wizard/history/max_history_entries'
@@ -114,6 +121,26 @@ func is_set_visible_track_automatically_enabled() -> bool:
 	return _get_project_setting(_SET_VISIBLE_TRACK_AUTOMATICALLY, false)
 
 
+func is_normalmap_enabled() -> bool:
+	return _get_project_setting(_NORMALMAP_ENABLED_KEY, false)
+
+
+func get_normalmap_emboss_height() -> float:
+	return _get_project_setting(_NORMALMAP_EMBOSS_HEIGHT_KEY, 2.0)
+
+
+func get_normalmap_bump_height() -> float:
+	return _get_project_setting(_NORMALMAP_BUMP_HEIGHT_KEY, 8.0)
+
+
+func get_normalmap_blur() -> int:
+	return _get_project_setting(_NORMALMAP_BLUR_KEY, 2)
+
+
+func get_normalmap_bump() -> int:
+	return _get_project_setting(_NORMALMAP_BUMP_KEY, 150)
+
+
 func save_import_history(history: Array):
 	set_plugin_metadata(_WIZARD_HISTORY, history)
 
@@ -172,6 +199,12 @@ func initialize_project_settings():
 
 	_initialize_project_cfg(_SET_VISIBLE_TRACK_AUTOMATICALLY, false, TYPE_BOOL)
 
+	_initialize_project_cfg(_NORMALMAP_ENABLED_KEY, false, TYPE_BOOL)
+	_initialize_project_cfg(_NORMALMAP_EMBOSS_HEIGHT_KEY, 2.0, TYPE_FLOAT)
+	_initialize_project_cfg(_NORMALMAP_BUMP_HEIGHT_KEY, 8.0, TYPE_FLOAT)
+	_initialize_project_cfg(_NORMALMAP_BLUR_KEY, 2, TYPE_INT)
+	_initialize_project_cfg(_NORMALMAP_BUMP_KEY, 150, TYPE_INT)
+
 	ProjectSettings.save()
 
 	_initialize_editor_cfg(_COMMAND_KEY, default_command(), TYPE_STRING)
@@ -188,6 +221,11 @@ func clear_project_settings():
 		_SET_VISIBLE_TRACK_AUTOMATICALLY,
 		_DEFAULT_ONLY_VISIBLE_LAYERS,
 		_IMPORTER_GENERATE_BAKE_FILE_KEY,
+		_NORMALMAP_ENABLED_KEY,
+		_NORMALMAP_EMBOSS_HEIGHT_KEY,
+		_NORMALMAP_BUMP_HEIGHT_KEY,
+		_NORMALMAP_BLUR_KEY,
+		_NORMALMAP_BUMP_KEY,
 	]
 	for key in _all_settings:
 		ProjectSettings.clear(key)

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -2,6 +2,7 @@
 extends "../base_sprite_resource_creator.gd"
 
 const wizard_config = preload("../../config/wizard_config.gd")
+var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
 
 var _DEFAULT_ANIMATION_LIBRARY = "" # GLOBAL
 
@@ -30,6 +31,24 @@ func _import(target_node: Node, player: AnimationPlayer, aseprite_files: Diction
 		target_node.texture_filter = BaseMaterial3D.TEXTURE_FILTER_NEAREST
 
 	var texture := _load_texture(sprite_sheet, options.get("should_create_portable_texture", false))
+
+	if options.get("normalmap_generate", false):
+		var params: Dictionary = options.get("normalmap_params", {})
+		var global_path = ProjectSettings.globalize_path(sprite_sheet)
+		var source_image = Image.load_from_file(global_path)
+		if source_image != null and not source_image.is_empty():
+			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
+
+			if options.get("normalmap_save_debug_png", false):
+				var base = sprite_sheet.get_basename()
+				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
+
+			var normal_tex := PortableCompressedTexture2D.new()
+			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+			var canvas_tex := CanvasTexture.new()
+			canvas_tex.diffuse_texture = texture
+			canvas_tex.normal_texture = normal_tex
+			texture = canvas_tex
 
 	_setup_texture(target_node, texture, content, context, options.slice != "")
 	var result = _configure_animations(target_node, player, content, context, options)

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -2,7 +2,6 @@
 extends "../base_sprite_resource_creator.gd"
 
 const wizard_config = preload("../../config/wizard_config.gd")
-var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
 
 var _DEFAULT_ANIMATION_LIBRARY = "" # GLOBAL
 
@@ -32,22 +31,16 @@ func _import(target_node: Node, player: AnimationPlayer, aseprite_files: Diction
 
 	var texture := _load_texture(sprite_sheet, options.get("should_create_portable_texture", false))
 
-	if options.get("normalmap_generate", false):
-		var params: Dictionary = options.get("normalmap_params", {})
-		var global_path = ProjectSettings.globalize_path(sprite_sheet)
-		var source_image = Image.load_from_file(global_path)
-		if source_image != null and not source_image.is_empty():
-			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
-
-			if options.get("normalmap_save_debug_png", false):
-				var base = sprite_sheet.get_basename()
-				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
-
-			var normal_tex := PortableCompressedTexture2D.new()
-			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
-			var canvas_tex := CanvasTexture.new()
-			canvas_tex.diffuse_texture = texture
-			canvas_tex.normal_texture = normal_tex
+	var normalmap_tex: Texture2D = options.get("normalmap_texture")
+	if normalmap_tex != null:
+		var canvas_tex := CanvasTexture.new()
+		canvas_tex.diffuse_texture = texture
+		canvas_tex.normal_texture = normalmap_tex
+		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
+			var tres_path := sprite_sheet.get_basename() + ".tres"
+			ResourceSaver.save(canvas_tex, tres_path)
+			texture = ResourceLoader.load(tres_path)
+		else:
 			texture = canvas_tex
 
 	_setup_texture(target_node, texture, content, context, options.slice != "")

--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -36,12 +36,12 @@ func _import(target_node: Node, player: AnimationPlayer, aseprite_files: Diction
 		var canvas_tex := CanvasTexture.new()
 		canvas_tex.diffuse_texture = texture
 		canvas_tex.normal_texture = normalmap_tex
-		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
-			var tres_path := sprite_sheet.get_basename() + ".tres"
-			ResourceSaver.save(canvas_tex, tres_path)
-			texture = ResourceLoader.load(tres_path)
-		else:
-			texture = canvas_tex
+		texture = canvas_tex
+
+	if not options.get("normalmap_embed_resource", true):
+		var tres_path := sprite_sheet.get_basename() + ".tres"
+		ResourceSaver.save(texture, tres_path)
+		texture = ResourceLoader.load(tres_path)
 
 	_setup_texture(target_node, texture, content, context, options.slice != "")
 	var result = _configure_animations(target_node, player, content, context, options)

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -1,8 +1,6 @@
 @tool
 extends "../base_sprite_resource_creator.gd"
 
-var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
-
 enum {
 	FILE_EXPORT_MODE,
 	LAYERS_EXPORT_MODE
@@ -101,23 +99,16 @@ func _load_or_create_texture_resource(sprite_sheet: String, options: Dictionary)
 		extra_gen_files.append(texture_path)
 
 	# Wrap in CanvasTexture with normal map if requested
-	if options.get("normalmap_generate", false):
-		var params: Dictionary = options.get("normalmap_params", {})
-		var global_path = ProjectSettings.globalize_path(sprite_sheet)
-		var source_image = Image.load_from_file(global_path)
-		if source_image != null and not source_image.is_empty():
-			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
-
-			if options.get("normalmap_save_debug_png", false):
-				var base = sprite_sheet.get_basename()
-				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
-
-			var normal_tex := PortableCompressedTexture2D.new()
-			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
-
-			var canvas_tex := CanvasTexture.new()
-			canvas_tex.diffuse_texture = diffuse_tex
-			canvas_tex.normal_texture = normal_tex
+	var normalmap_tex: Texture2D = options.get("normalmap_texture")
+	if normalmap_tex != null:
+		var canvas_tex := CanvasTexture.new()
+		canvas_tex.diffuse_texture = diffuse_tex
+		canvas_tex.normal_texture = normalmap_tex
+		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
+			var tres_path := sprite_sheet.get_basename() + ".tres"
+			ResourceSaver.save(canvas_tex, tres_path)
+			return { "texture": ResourceLoader.load(tres_path), "extra_gen_files": extra_gen_files }
+		else:
 			return { "texture": canvas_tex, "extra_gen_files": extra_gen_files }
 
 	return { "texture": diffuse_tex, "extra_gen_files": extra_gen_files }

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -104,12 +104,12 @@ func _load_or_create_texture_resource(sprite_sheet: String, options: Dictionary)
 		var canvas_tex := CanvasTexture.new()
 		canvas_tex.diffuse_texture = diffuse_tex
 		canvas_tex.normal_texture = normalmap_tex
-		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
-			var tres_path := sprite_sheet.get_basename() + ".tres"
-			ResourceSaver.save(canvas_tex, tres_path)
-			return { "texture": ResourceLoader.load(tres_path), "extra_gen_files": extra_gen_files }
-		else:
-			return { "texture": canvas_tex, "extra_gen_files": extra_gen_files }
+		diffuse_tex = canvas_tex
+
+	if not options.get("normalmap_embed_resource", true):
+		var tres_path := sprite_sheet.get_basename() + ".tres"
+		ResourceSaver.save(diffuse_tex, tres_path)
+		return { "texture": ResourceLoader.load(tres_path), "extra_gen_files": extra_gen_files }
 
 	return { "texture": diffuse_tex, "extra_gen_files": extra_gen_files }
 

--- a/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
+++ b/addons/AsepriteWizard/creators/sprite_frames/sprite_frames_creator.gd
@@ -1,6 +1,8 @@
 @tool
 extends "../base_sprite_resource_creator.gd"
 
+var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
+
 enum {
 	FILE_EXPORT_MODE,
 	LAYERS_EXPORT_MODE
@@ -80,27 +82,45 @@ func _load_aseprite_resources(aseprite_data: Dictionary, options: Dictionary) ->
 
 
 func _load_or_create_texture_resource(sprite_sheet: String, options: Dictionary) -> Dictionary:
+	var diffuse_tex: Texture2D = null
+	var extra_gen_files := []
+
 	if not options.get("should_create_portable_texture", false):
-		var tex = _load_texture(sprite_sheet)
-		if tex == null:
+		diffuse_tex = _load_texture(sprite_sheet)
+		if diffuse_tex == null:
 			return { "texture": null, "error": true, "extra_gen_files": [] }
-		return { "texture": tex, "extra_gen_files": [] }
-
-	if options.get("sheet_base_path", "") == "":
-		var tex = create_packed_texture(sprite_sheet)
-		if tex == null:
+	elif options.get("sheet_base_path", "") == "":
+		diffuse_tex = create_packed_texture(sprite_sheet)
+		if diffuse_tex == null:
 			return { "texture": null, "error": true, "extra_gen_files": [] }
-		return { "texture": tex, "extra_gen_files": [] }
+	else:
+		var texture_path = "%s.%s.texture.res" % [options.sheet_base_path, sprite_sheet.get_file().get_basename()]
+		diffuse_tex = create_packed_texture(sprite_sheet, texture_path)
+		if diffuse_tex == null:
+			return { "texture": null, "error": true, "extra_gen_files": [texture_path] }
+		extra_gen_files.append(texture_path)
 
-	var texture_path = "%s.%s.texture.res" % [options.sheet_base_path, sprite_sheet.get_file().get_basename() ]
-	var tex = create_packed_texture(sprite_sheet, texture_path)
-	if tex == null:
-		return { "texture": null, "error": true, "extra_gen_files": [texture_path] }
+	# Wrap in CanvasTexture with normal map if requested
+	if options.get("normalmap_generate", false):
+		var params: Dictionary = options.get("normalmap_params", {})
+		var global_path = ProjectSettings.globalize_path(sprite_sheet)
+		var source_image = Image.load_from_file(global_path)
+		if source_image != null and not source_image.is_empty():
+			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
 
-	return {
-		"texture": tex,
-		"extra_gen_files": [texture_path]
-	}
+			if options.get("normalmap_save_debug_png", false):
+				var base = sprite_sheet.get_basename()
+				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
+
+			var normal_tex := PortableCompressedTexture2D.new()
+			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+
+			var canvas_tex := CanvasTexture.new()
+			canvas_tex.diffuse_texture = diffuse_tex
+			canvas_tex.normal_texture = normal_tex
+			return { "texture": canvas_tex, "extra_gen_files": extra_gen_files }
+
+	return { "texture": diffuse_tex, "extra_gen_files": extra_gen_files }
 
 
 func save_resources(resources: Array) -> int:

--- a/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
+++ b/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
@@ -1,8 +1,6 @@
 @tool
 extends "../base_sprite_resource_creator.gd"
 
-var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
-
 func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictionary) -> void:
 	var source_file = aseprite_files.data_file
 	var sprite_sheet = aseprite_files.sprite_sheet
@@ -18,22 +16,16 @@ func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictio
 		logger.error("Failed to load aseprite source", source_file)
 		return
 
-	if options.get("normalmap_generate", false):
-		var params: Dictionary = options.get("normalmap_params", {})
-		var global_path = ProjectSettings.globalize_path(sprite_sheet)
-		var source_image = Image.load_from_file(global_path)
-		if source_image != null and not source_image.is_empty():
-			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
-
-			if options.get("normalmap_save_debug_png", false):
-				var base = sprite_sheet.get_basename()
-				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
-
-			var normal_tex := PortableCompressedTexture2D.new()
-			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
-			var canvas_tex := CanvasTexture.new()
-			canvas_tex.diffuse_texture = texture
-			canvas_tex.normal_texture = normal_tex
+	var normalmap_tex: Texture2D = options.get("normalmap_texture")
+	if normalmap_tex != null:
+		var canvas_tex := CanvasTexture.new()
+		canvas_tex.diffuse_texture = texture
+		canvas_tex.normal_texture = normalmap_tex
+		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
+			var tres_path := sprite_sheet.get_basename() + ".tres"
+			ResourceSaver.save(canvas_tex, tres_path)
+			texture = ResourceLoader.load(tres_path)
+		else:
 			texture = canvas_tex
 
 	if options.slice == "":

--- a/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
+++ b/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
@@ -1,6 +1,8 @@
 @tool
 extends "../base_sprite_resource_creator.gd"
 
+var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
+
 func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictionary) -> void:
 	var source_file = aseprite_files.data_file
 	var sprite_sheet = aseprite_files.sprite_sheet
@@ -15,6 +17,24 @@ func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictio
 	if not data.is_ok:
 		logger.error("Failed to load aseprite source", source_file)
 		return
+
+	if options.get("normalmap_generate", false):
+		var params: Dictionary = options.get("normalmap_params", {})
+		var global_path = ProjectSettings.globalize_path(sprite_sheet)
+		var source_image = Image.load_from_file(global_path)
+		if source_image != null and not source_image.is_empty():
+			var normal_img = _normal_map_generator.generate_normal_map(source_image, params)
+
+			if options.get("normalmap_save_debug_png", false):
+				var base = sprite_sheet.get_basename()
+				normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
+
+			var normal_tex := PortableCompressedTexture2D.new()
+			normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+			var canvas_tex := CanvasTexture.new()
+			canvas_tex.diffuse_texture = texture
+			canvas_tex.normal_texture = normal_tex
+			texture = canvas_tex
 
 	if options.slice == "":
 		target_node.texture = texture

--- a/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
+++ b/addons/AsepriteWizard/creators/static_texture/texture_creator.gd
@@ -21,12 +21,12 @@ func load_texture(target_node: Node, aseprite_files: Dictionary, options: Dictio
 		var canvas_tex := CanvasTexture.new()
 		canvas_tex.diffuse_texture = texture
 		canvas_tex.normal_texture = normalmap_tex
-		if not options.get("should_create_portable_texture", false) and not options.get("normalmap_embed_resource", true):
-			var tres_path := sprite_sheet.get_basename() + ".tres"
-			ResourceSaver.save(canvas_tex, tres_path)
-			texture = ResourceLoader.load(tres_path)
-		else:
-			texture = canvas_tex
+		texture = canvas_tex
+
+	if not options.get("normalmap_embed_resource", true):
+		var tres_path := sprite_sheet.get_basename() + ".tres"
+		ResourceSaver.save(texture, tres_path)
+		texture = ResourceLoader.load(tres_path)
 
 	if options.slice == "":
 		target_node.texture = texture

--- a/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/sprite_frames_import_plugin.gd
@@ -8,6 +8,7 @@ var config = preload("../config/config.gd").new()
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 var _sf_creator = preload("../creators/sprite_frames/sprite_frames_creator.gd").new()
 var _bakery = preload("./helpers/bakery.gd").new()
+var _normal_map_generator = preload("../normalmap/normal_map_generator.gd")
 var file_system: EditorFileSystem = EditorInterface.get_resource_filesystem()
 
 
@@ -70,10 +71,38 @@ func _get_import_options(_path, _i):
 			"default_value": 1,
 		},
 		{"name": "animation/round_fps", "default_value": true},
+		{"name": "normalmap/generate", "default_value": config.is_normalmap_enabled()},
+		{
+			"name": "normalmap/emboss_height",
+			"default_value": config.get_normalmap_emboss_height(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,100,0.01",
+		},
+		{
+			"name": "normalmap/bump_height",
+			"default_value": config.get_normalmap_bump_height(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,100,0.01",
+		},
+		{
+			"name": "normalmap/blur",
+			"default_value": config.get_normalmap_blur(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,10,1",
+		},
+		{
+			"name": "normalmap/bump",
+			"default_value": config.get_normalmap_bump(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,500,1",
+		},
+		{"name": "normalmap/save_debug_png", "default_value": false},
 	]
 
 
 func _get_option_visibility(path, option, options):
+	if option.begins_with("normalmap/") and option != "normalmap/generate":
+		return options.get("normalmap/generate", false)
 	return true
 
 
@@ -115,6 +144,13 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var resources = _sf_creator.create_resources(source_files.content, {
 		"should_round_fps": options["animation/round_fps"],
 		"should_create_portable_texture": true,
+		"normalmap_generate": options.get("normalmap/generate", false),
+		"normalmap_params": {
+			"emboss_height": options.get("normalmap/emboss_height", 0.1),
+			"bump_height": options.get("normalmap/bump_height", 0.3),
+			"blur": options.get("normalmap/blur", 5),
+			"bump": options.get("normalmap/bump", 60),
+		},
 	})
 
 	if not resources.is_ok:
@@ -135,6 +171,20 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if config.should_remove_source_files():
 		_remove_source_files(source_files.content)
+
+	# Save debug normal map PNGs if requested
+	if options.get("normalmap/generate", false) and options.get("normalmap/save_debug_png", false):
+		for s in source_files.content:
+			var sheet_path: String = s.sprite_sheet
+			var global_sheet = ProjectSettings.globalize_path(sheet_path)
+			# Even if source files were removed, we still have the image in the resource.
+			# Load from the original path if it still exists, otherwise skip.
+			if FileAccess.file_exists(global_sheet) or FileAccess.file_exists(sheet_path):
+				var img = Image.load_from_file(global_sheet)
+				if img:
+					var normal_img = _normal_map_generator.generate_normal_map(img, options.get("normalmap/params", {}))
+					var base = sheet_path.get_basename()
+					normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
 
 	if exit_code != OK:
 		logger.error("Could not persist aseprite file: %s" % result_codes.get_error_message(exit_code), source_file)

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin.gd
@@ -43,6 +43,32 @@ func _get_import_options(_path, _i):
 			"name": "sheet/scale",
 			"default_value": 1,
 		},
+		{"name": "normalmap/generate", "default_value": config.is_normalmap_enabled()},
+		{
+			"name": "normalmap/emboss_height",
+			"default_value": config.get_normalmap_emboss_height(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,100,0.01",
+		},
+		{
+			"name": "normalmap/bump_height",
+			"default_value": config.get_normalmap_bump_height(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,100,0.01",
+		},
+		{
+			"name": "normalmap/blur",
+			"default_value": config.get_normalmap_blur(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,10,1",
+		},
+		{
+			"name": "normalmap/bump",
+			"default_value": config.get_normalmap_bump(),
+			"property_hint": PROPERTY_HINT_RANGE,
+			"hint_string": "0,500,1",
+		},
+		{"name": "normalmap/save_debug_png", "default_value": false},
 	]
 
 func _import(source_file, save_path, options, platform_variants, gen_files):
@@ -50,7 +76,7 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 
 	if bake_result != CONTINUE_STATUS_CODE:
 		return bake_result
-	
+
 	var absolute_source_file = ProjectSettings.globalize_path(source_file)
 	var source_path = source_file.get_base_dir()
 
@@ -78,4 +104,13 @@ func _import(source_file, save_path, options, platform_variants, gen_files):
 	var sprite_sheet = result.content.sprite_sheet
 	var data = result.content.data
 
-	return _save_resource(source_file, sprite_sheet, save_path, result.content.data_file, data.meta.size)
+	return _save_resource(source_file, sprite_sheet, save_path, result.content.data_file, data.meta.size, {
+		"generate": options.get("normalmap/generate", false),
+		"params": {
+			"emboss_height": options.get("normalmap/emboss_height", 0.1),
+			"bump_height": options.get("normalmap/bump_height", 0.3),
+			"blur": options.get("normalmap/blur", 5),
+			"bump": options.get("normalmap/bump", 60),
+		},
+		"save_debug_png": options.get("normalmap/save_debug_png", false),
+	})

--- a/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
+++ b/addons/AsepriteWizard/importers/static_texture_import_plugin_base.gd
@@ -5,6 +5,7 @@ const result_codes = preload("../config/result_codes.gd")
 const logger = preload("../config/logger.gd")
 var _aseprite_file_exporter = preload("../aseprite/file_exporter.gd").new()
 var _bakery = preload("./helpers/bakery.gd").new()
+var _normal_map_generator = preload("../normalmap/normal_map_generator.gd")
 
 var config = preload("../config/config.gd").new()
 
@@ -15,7 +16,7 @@ func _get_save_extension():
 
 
 func _get_resource_type():
-	return "PortableCompressedTexture2D"
+	return "Texture2D"
 
 
 func _get_preset_count():
@@ -31,6 +32,8 @@ func _get_import_order():
 
 
 func _get_option_visibility(path, option, options):
+	if option.begins_with("normalmap/") and option != "normalmap/generate":
+		return options.get("normalmap/generate", false)
 	return true
 
 
@@ -55,13 +58,31 @@ func _generate_texture(absolute_source_file: String, options: Dictionary) -> Dic
 	})
 
 
-func _save_resource(source_file: String, sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary) -> int:
+func _save_resource(source_file: String, sprite_sheet: String, save_path: String, data_file_path: String, size: Dictionary, normalmap_options: Dictionary = {}) -> int:
 	var image = Image.load_from_file(ProjectSettings.globalize_path(sprite_sheet))
 
 	var tex := PortableCompressedTexture2D.new()
 	tex.create_from_image(image, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
-#
-	var exit_code = ResourceSaver.save(tex, "%s.%s" % [save_path, _get_save_extension()])
+
+	var final_tex: Texture2D = tex
+
+	if normalmap_options.get("generate", false):
+		var params: Dictionary = normalmap_options.get("params", {})
+		var normal_img = _normal_map_generator.generate_normal_map(image, params)
+
+		if normalmap_options.get("save_debug_png", false):
+			var base = sprite_sheet.get_basename()
+			normal_img.save_png(ProjectSettings.globalize_path(base + "_n.png"))
+
+		var normal_tex := PortableCompressedTexture2D.new()
+		normal_tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+
+		var canvas_tex := CanvasTexture.new()
+		canvas_tex.diffuse_texture = tex
+		canvas_tex.normal_texture = normal_tex
+		final_tex = canvas_tex
+
+	var exit_code = ResourceSaver.save(final_tex, "%s.%s" % [save_path, _get_save_extension()])
 
 	if config.should_remove_source_files():
 		DirAccess.remove_absolute(data_file_path)
@@ -72,7 +93,7 @@ func _save_resource(source_file: String, sprite_sheet: String, save_path: String
 		return FAILED
 
 	if config.should_generate_bake_files():
-		var bake_code = _bakery.save_bake_file(source_file, tex)
+		var bake_code = _bakery.save_bake_file(source_file, final_tex)
 		if bake_code != OK:
 			logger.error('Bake file creation failed (%s)' % bake_code, source_file)
 

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
@@ -49,18 +49,16 @@ func _do_import():
 	file_system.scan()
 	await file_system.filesystem_changed
 
+	var normalmap_tex: Texture2D = null
+	if _normalmap_generate_field.button_pressed:
+		normalmap_tex = await _prepare_normal_texture(aseprite_output.content.sprite_sheet)
+
 	sprite_frames_creator.create_animations(target_node, aseprite_output.content, {
 		"slice": _slice,
 		"should_round_fps": _round_fps.button_pressed,
 		"should_create_portable_texture": _embed_field.button_pressed,
-		"normalmap_generate": _normalmap_generate_field.button_pressed,
-		"normalmap_params": {
-			"emboss_height": _normalmap_emboss_height_field.value,
-			"bump_height": _normalmap_bump_height_field.value,
-			"blur": int(_normalmap_blur_field.value),
-			"bump": int(_normalmap_bump_field.value),
-		},
-		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
+		"normalmap_texture": normalmap_tex,
+		"normalmap_embed_resource": _normalmap_embed_resource_field.button_pressed,
 	})
 
 	wizard_config.set_source_hash(target_node, FileAccess.get_md5(source_path))

--- a/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/animated_sprite/animated_sprite_inspector_dock.gd
@@ -53,6 +53,14 @@ func _do_import():
 		"slice": _slice,
 		"should_round_fps": _round_fps.button_pressed,
 		"should_create_portable_texture": _embed_field.button_pressed,
+		"normalmap_generate": _normalmap_generate_field.button_pressed,
+		"normalmap_params": {
+			"emboss_height": _normalmap_emboss_height_field.value,
+			"bump_height": _normalmap_bump_height_field.value,
+			"blur": int(_normalmap_blur_field.value),
+			"bump": int(_normalmap_bump_field.value),
+		},
+		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
 	})
 
 	wizard_config.set_source_hash(target_node, FileAccess.get_md5(source_path))

--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -214,7 +214,7 @@ func _load_common_config(cfg):
 	_visible_layers_field.button_pressed = cfg.get("only_visible", false)
 	_ex_pattern_field.text = cfg.get("o_ex_p", "")
 
-	_embed_field.button_pressed = cfg.get("embed_tex", false)
+	_embed_field.button_pressed = cfg.get("embed_tex", true)
 	_scale_field.value = float(cfg.get("scale", 1))
 
 	_normalmap_generate_field.button_pressed = cfg.get("normalmap_generate", config.is_normalmap_enabled())
@@ -308,6 +308,8 @@ func _setup_field_listeners():
 
 	_embed_field.pressed.connect(_on_embed_button_pressed)
 	_normalmap_generate_field.pressed.connect(_on_normalmap_generate_pressed)
+	_normalmap_embed_resource_field.pressed.connect(_on_embed_resource_button_pressed)
+	_normalmap_embed_resource_field.pressed.connect(_on_embed_resource_button_pressed)
 
 
 func _on_layer_header_button_down():
@@ -502,6 +504,10 @@ func _on_embed_button_pressed():
 	_handle_embed_visibility()
 
 
+func _on_embed_resource_button_pressed():
+	_handle_embed_visibility()
+
+
 func _on_normalmap_generate_pressed():
 	_handle_embed_visibility()
 
@@ -539,15 +545,14 @@ func _prepare_normal_texture(sprite_sheet: String) -> Texture2D:
 
 func _handle_embed_visibility():
 	var embed_on := _embed_field.button_pressed
-	var normalmap_on := _normalmap_generate_field.button_pressed
-	if embed_on:
+	var embed_res_on := _normalmap_embed_resource_field.button_pressed
+	# Hide folder/filename only when both embed modes are ON (nothing written to disk)
+	if embed_on and embed_res_on:
 		_out_folder_container.hide()
 		_out_filename_container.hide()
-		_normalmap_embed_resource_container.hide()
 	else:
 		_out_folder_container.show()
 		_out_filename_container.show()
-		_normalmap_embed_resource_container.visible = normalmap_on
 
 
 func _show_message(message: String):

--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -55,16 +55,28 @@ var _interface_section_state
 
 @onready var _scale_field :=  $dock_fields/VBoxContainer/extra/sections/output/section_content/content/scale/SpinBox as SpinBox
 
+# normalmap
+@onready var _normalmap_section_header := $dock_fields/VBoxContainer/extra/sections/normalmap/section_header as Button
+@onready var _normalmap_section_container := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content as MarginContainer
+@onready var _normalmap_generate_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/generate/CheckBox as CheckBox
+@onready var _normalmap_emboss_height_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/emboss_height/SpinBox as SpinBox
+@onready var _normalmap_bump_height_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/bump_height/SpinBox as SpinBox
+@onready var _normalmap_blur_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/blur/SpinBox as SpinBox
+@onready var _normalmap_bump_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/bump/SpinBox as SpinBox
+@onready var _normalmap_save_debug_png_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png/CheckBox as CheckBox
+
 
 @onready var _import_button := $dock_fields/VBoxContainer/import as Button
 
 const INTERFACE_SECTION_KEY_LAYER = "layer_section"
 const INTERFACE_SECTION_KEY_SLICE = "slice_section"
+const INTERFACE_SECTION_KEY_NORMALMAP = "normalmap_section"
 const INTERFACE_SECTION_KEY_OUTPUT = "output_section"
 
 @onready var _expandable_sections = {
 	INTERFACE_SECTION_KEY_LAYER: { "header": _layer_section_header, "content": _layer_section_container},
 	INTERFACE_SECTION_KEY_SLICE: { "header": _slice_section_header, "content": _slice_section_container},
+	INTERFACE_SECTION_KEY_NORMALMAP: { "header": _normalmap_section_header, "content": _normalmap_section_container},
 	INTERFACE_SECTION_KEY_OUTPUT: { "header": _output_section_header, "content": _output_section_container},
 }
 
@@ -203,6 +215,13 @@ func _load_common_config(cfg):
 	_embed_field.button_pressed = cfg.get("embed_tex", false)
 	_scale_field.value = float(cfg.get("scale", 1))
 
+	_normalmap_generate_field.button_pressed = cfg.get("normalmap_generate", config.is_normalmap_enabled())
+	_normalmap_emboss_height_field.value = cfg.get("normalmap_emboss_height", config.get_normalmap_emboss_height())
+	_normalmap_bump_height_field.value = cfg.get("normalmap_bump_height", config.get_normalmap_bump_height())
+	_normalmap_blur_field.value = cfg.get("normalmap_blur", config.get_normalmap_blur())
+	_normalmap_bump_field.value = cfg.get("normalmap_bump", config.get_normalmap_bump())
+	_normalmap_save_debug_png_field.button_pressed = cfg.get("normalmap_save_debug_png", false)
+
 	_load_config(cfg)
 	_handle_embed_visibility()
 
@@ -268,6 +287,7 @@ func _adjust_icon(section: Button, is_visible: bool = true) -> void:
 func _setup_field_listeners():
 	_layer_section_header.button_down.connect(_on_layer_header_button_down)
 	_slice_section_header.button_down.connect(_on_slice_header_button_down)
+	_normalmap_section_header.button_down.connect(_on_normalmap_header_button_down)
 	_output_section_header.button_down.connect(_on_output_header_button_down)
 
 	_source_field.pressed.connect(_on_source_pressed)
@@ -293,6 +313,10 @@ func _on_layer_header_button_down():
 
 func _on_slice_header_button_down():
 	_toggle_section_visibility(INTERFACE_SECTION_KEY_SLICE)
+
+
+func _on_normalmap_header_button_down():
+	_toggle_section_visibility(INTERFACE_SECTION_KEY_NORMALMAP)
 
 
 func _on_output_header_button_down():
@@ -365,6 +389,12 @@ func _get_current_config():
 		"o_ex_p": _ex_pattern_field.text,
 		"embed_tex": _embed_field.button_pressed,
 		"scale": str(_scale_field.value),
+		"normalmap_generate": _normalmap_generate_field.button_pressed,
+		"normalmap_emboss_height": _normalmap_emboss_height_field.value,
+		"normalmap_bump_height": _normalmap_bump_height_field.value,
+		"normalmap_blur": int(_normalmap_blur_field.value),
+		"normalmap_bump": int(_normalmap_bump_field.value),
+		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
 	}
 
 	for c in child_config:

--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -6,6 +6,7 @@ const wizard_config = preload("../../config/wizard_config.gd")
 const result_code = preload("../../config/result_codes.gd")
 var _aseprite_file_exporter = preload("../../aseprite/file_exporter.gd").new()
 var config = preload("../../config/config.gd").new()
+var _normal_map_generator = preload("../../normalmap/normal_map_generator.gd")
 
 var scene: Node
 var target_node: Node
@@ -63,7 +64,8 @@ var _interface_section_state
 @onready var _normalmap_bump_height_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/bump_height/SpinBox as SpinBox
 @onready var _normalmap_blur_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/blur/SpinBox as SpinBox
 @onready var _normalmap_bump_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/bump/SpinBox as SpinBox
-@onready var _normalmap_save_debug_png_field := $dock_fields/VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png/CheckBox as CheckBox
+@onready var _normalmap_embed_resource_field :=  $dock_fields/VBoxContainer/extra/sections/output/section_content/content/normalmap_embed_resource/CheckBox as CheckBox
+@onready var _normalmap_embed_resource_container := $dock_fields/VBoxContainer/extra/sections/output/section_content/content/normalmap_embed_resource as HBoxContainer
 
 
 @onready var _import_button := $dock_fields/VBoxContainer/import as Button
@@ -220,7 +222,7 @@ func _load_common_config(cfg):
 	_normalmap_bump_height_field.value = cfg.get("normalmap_bump_height", config.get_normalmap_bump_height())
 	_normalmap_blur_field.value = cfg.get("normalmap_blur", config.get_normalmap_blur())
 	_normalmap_bump_field.value = cfg.get("normalmap_bump", config.get_normalmap_bump())
-	_normalmap_save_debug_png_field.button_pressed = cfg.get("normalmap_save_debug_png", false)
+	_normalmap_embed_resource_field.button_pressed = cfg.get("normalmap_embed_resource", true)
 
 	_load_config(cfg)
 	_handle_embed_visibility()
@@ -305,6 +307,7 @@ func _setup_field_listeners():
 	_import_button.pressed.connect(_on_import_pressed)
 
 	_embed_field.pressed.connect(_on_embed_button_pressed)
+	_normalmap_generate_field.pressed.connect(_on_normalmap_generate_pressed)
 
 
 func _on_layer_header_button_down():
@@ -394,7 +397,7 @@ func _get_current_config():
 		"normalmap_bump_height": _normalmap_bump_height_field.value,
 		"normalmap_blur": int(_normalmap_blur_field.value),
 		"normalmap_bump": int(_normalmap_bump_field.value),
-		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
+		"normalmap_embed_resource": _normalmap_embed_resource_field.button_pressed,
 	}
 
 	for c in child_config:
@@ -499,13 +502,52 @@ func _on_embed_button_pressed():
 	_handle_embed_visibility()
 
 
-func _handle_embed_visibility():
+func _on_normalmap_generate_pressed():
+	_handle_embed_visibility()
+
+
+## Generates the normal map for a sprite sheet and returns a ready-to-use Texture2D.
+## When Embed Texture is ON: returns an embedded PortableCompressedTexture2D (no file written).
+## When Embed Texture is OFF: saves _n.png, triggers a filesystem scan so Godot imports it,
+## then returns the imported file reference via ResourceLoader.
+func _prepare_normal_texture(sprite_sheet: String) -> Texture2D:
+	var params := {
+		"emboss_height": _normalmap_emboss_height_field.value,
+		"bump_height": _normalmap_bump_height_field.value,
+		"blur": int(_normalmap_blur_field.value),
+		"bump": int(_normalmap_bump_field.value),
+	}
+	var global_path := ProjectSettings.globalize_path(sprite_sheet)
+	var source_image := Image.load_from_file(global_path)
+	if source_image == null or source_image.is_empty():
+		return null
+	var normal_img := _normal_map_generator.generate_normal_map(source_image, params)
+
 	if _embed_field.button_pressed:
+		# Embed Texture ON: keep normal data in memory, no file on disk
+		var tex := PortableCompressedTexture2D.new()
+		tex.create_from_image(normal_img, PortableCompressedTexture2D.COMPRESSION_MODE_LOSSLESS)
+		return tex
+	else:
+		# Embed Texture OFF: write _n.png, scan so Godot imports it, return file reference
+		var n_png_path := sprite_sheet.get_basename() + "_n.png"
+		normal_img.save_png(ProjectSettings.globalize_path(n_png_path))
+		file_system.scan()
+		await file_system.filesystem_changed
+		return ResourceLoader.load(n_png_path)
+
+
+func _handle_embed_visibility():
+	var embed_on := _embed_field.button_pressed
+	var normalmap_on := _normalmap_generate_field.button_pressed
+	if embed_on:
 		_out_folder_container.hide()
 		_out_filename_container.hide()
+		_normalmap_embed_resource_container.hide()
 	else:
 		_out_folder_container.show()
 		_out_filename_container.show()
+		_normalmap_embed_resource_container.visible = normalmap_on
 
 
 func _show_message(message: String):

--- a/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/base_inspector_dock.gd
@@ -69,6 +69,7 @@ var _interface_section_state
 
 
 @onready var _import_button := $dock_fields/VBoxContainer/import as Button
+@onready var _normalmap_status_label := $dock_fields/VBoxContainer/normalmap_status as Label
 
 const INTERFACE_SECTION_KEY_LAYER = "layer_section"
 const INTERFACE_SECTION_KEY_SLICE = "slice_section"
@@ -513,9 +514,7 @@ func _on_normalmap_generate_pressed():
 
 
 ## Generates the normal map for a sprite sheet and returns a ready-to-use Texture2D.
-## When Embed Texture is ON: returns an embedded PortableCompressedTexture2D (no file written).
-## When Embed Texture is OFF: saves _n.png, triggers a filesystem scan so Godot imports it,
-## then returns the imported file reference via ResourceLoader.
+## Runs the CPU-heavy generation in a background thread so the editor stays responsive.
 func _prepare_normal_texture(sprite_sheet: String) -> Texture2D:
 	var params := {
 		"emboss_height": _normalmap_emboss_height_field.value,
@@ -527,7 +526,17 @@ func _prepare_normal_texture(sprite_sheet: String) -> Texture2D:
 	var source_image := Image.load_from_file(global_path)
 	if source_image == null or source_image.is_empty():
 		return null
-	var normal_img := _normal_map_generator.generate_normal_map(source_image, params)
+
+	# Run the heavy generation in a background thread so Godot doesn't freeze
+	_normalmap_status_label.show()
+	var thread := Thread.new()
+	thread.start(func() -> Image:
+		return _normal_map_generator.generate_normal_map(source_image, params)
+	)
+	while thread.is_alive():
+		await get_tree().process_frame
+	var normal_img: Image = thread.wait_to_finish()
+	_normalmap_status_label.hide()
 
 	if _embed_field.button_pressed:
 		# Embed Texture ON: keep normal data in memory, no file on disk

--- a/addons/AsepriteWizard/interface/docks/dock_fields.tscn
+++ b/addons/AsepriteWizard/interface/docks/dock_fields.tscn
@@ -678,6 +678,13 @@ allow_greater = true
 layout_mode = 2
 text = "Import"
 
+[node name="normalmap_status" type="Label" parent="VBoxContainer"]
+visible = false
+layout_mode = 2
+auto_translate_mode = 0
+horizontal_alignment = 1
+text = "Generating normal map..."
+
 [node name="DebounceTimer" type="Timer" parent="."]
 wait_time = 0.6
 one_shot = true

--- a/addons/AsepriteWizard/interface/docks/dock_fields.tscn
+++ b/addons/AsepriteWizard/interface/docks/dock_fields.tscn
@@ -463,6 +463,134 @@ size_flags_stretch_ratio = 2.0
 button_pressed = true
 text = "On"
 
+[node name="normalmap" type="VBoxContainer" parent="VBoxContainer/extra/sections"]
+layout_mode = 2
+
+[node name="section_header" type="Button" parent="VBoxContainer/extra/sections/normalmap"]
+layout_mode = 2
+focus_mode = 0
+text = "Normal Map"
+icon = SubResource("ImageTexture_qqpl1")
+alignment = 0
+
+[node name="section_content" type="MarginContainer" parent="VBoxContainer/extra/sections/normalmap"]
+visible = false
+layout_mode = 2
+theme_override_constants/margin_left = 10
+
+[node name="content" type="VBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content"]
+layout_mode = 2
+
+[node name="generate" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Generate a normal map and wrap the texture in a CanvasTexture."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/generate"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Generate"
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/generate"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "On"
+
+[node name="emboss_height" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Emboss height for the normal map."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/emboss_height"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Emboss Height"
+
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/emboss_height"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+min_value = 0.0
+max_value = 100.0
+step = 0.01
+value = 2.0
+
+[node name="bump_height" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Bump height for the normal map."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/bump_height"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Bump Height"
+
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/bump_height"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+min_value = 0.0
+max_value = 100.0
+step = 0.01
+value = 8.0
+
+[node name="blur" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Gaussian blur radius for the normal map."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/blur"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Blur"
+
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/blur"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+min_value = 0.0
+max_value = 10.0
+step = 1.0
+value = 2.0
+rounded = true
+
+[node name="bump" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Bump intensity for the normal map."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/bump"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Bump"
+
+[node name="SpinBox" type="SpinBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/bump"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+min_value = 0.0
+max_value = 500.0
+step = 1.0
+value = 150.0
+rounded = true
+
+[node name="save_debug_png" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
+layout_mode = 2
+tooltip_text = "Save the generated normal map as a _n.png file on disk for debugging."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Save Debug PNG"
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "On"
+
 [node name="output" type="VBoxContainer" parent="VBoxContainer/extra/sections"]
 layout_mode = 2
 
@@ -562,6 +690,12 @@ one_shot = true
 [connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/ms/SpinBox" to="." method="_on_spin_box_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/extra/sections/animation/section_content/content/snap_to_fps/convert_ratio_container/convert_ratio/fps/fraction/SpinBox" to="." method="_on_spin_box_value_changed"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/animation_sf/section_content/content/round_fps/CheckBox" to="." method="_on_round_fps_toggled"]
+[connection signal="toggled" from="VBoxContainer/extra/sections/normalmap/section_content/content/generate/CheckBox" to="." method="_on_round_fps_toggled"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/emboss_height/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/bump_height/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/blur/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/bump/SpinBox" to="." method="_on_spin_box_value_changed"]
+[connection signal="toggled" from="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/output/section_content/content/embed/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="text_changed" from="VBoxContainer/extra/sections/output/section_content/content/out_filename/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="value_changed" from="VBoxContainer/extra/sections/output/section_content/content/scale/SpinBox" to="." method="_on_spin_box_value_changed"]

--- a/addons/AsepriteWizard/interface/docks/dock_fields.tscn
+++ b/addons/AsepriteWizard/interface/docks/dock_fields.tscn
@@ -611,7 +611,6 @@ button_pressed = true
 text = "On"
 
 [node name="normalmap_embed_resource" type="HBoxContainer" parent="VBoxContainer/extra/sections/output/section_content/content"]
-visible = false
 layout_mode = 2
 tooltip_text = "Embed the normal map resource directly in the scene. When disabled, a .tres file is saved on disk with the normal map resource."
 

--- a/addons/AsepriteWizard/interface/docks/dock_fields.tscn
+++ b/addons/AsepriteWizard/interface/docks/dock_fields.tscn
@@ -575,22 +575,6 @@ step = 1.0
 value = 150.0
 rounded = true
 
-[node name="save_debug_png" type="HBoxContainer" parent="VBoxContainer/extra/sections/normalmap/section_content/content"]
-layout_mode = 2
-tooltip_text = "Save the generated normal map as a _n.png file on disk for debugging."
-
-[node name="Label" type="Label" parent="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "Save Debug PNG"
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png"]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 2.0
-text = "On"
-
 [node name="output" type="VBoxContainer" parent="VBoxContainer/extra/sections"]
 layout_mode = 2
 
@@ -620,6 +604,24 @@ size_flags_stretch_ratio = 2.0
 text = "Embed Texture"
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/output/section_content/content/embed"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+button_pressed = true
+text = "On"
+
+[node name="normalmap_embed_resource" type="HBoxContainer" parent="VBoxContainer/extra/sections/output/section_content/content"]
+visible = false
+layout_mode = 2
+tooltip_text = "Embed the normal map resource directly in the scene. When disabled, a .tres file is saved on disk with the normal map resource."
+
+[node name="Label" type="Label" parent="VBoxContainer/extra/sections/output/section_content/content/normalmap_embed_resource"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 2.0
+text = "Embed Resource"
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/extra/sections/output/section_content/content/normalmap_embed_resource"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 2.0
@@ -695,7 +697,7 @@ one_shot = true
 [connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/bump_height/SpinBox" to="." method="_on_spin_box_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/blur/SpinBox" to="." method="_on_spin_box_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/extra/sections/normalmap/section_content/content/bump/SpinBox" to="." method="_on_spin_box_value_changed"]
-[connection signal="toggled" from="VBoxContainer/extra/sections/normalmap/section_content/content/save_debug_png/CheckBox" to="." method="_on_round_fps_toggled"]
+[connection signal="toggled" from="VBoxContainer/extra/sections/output/section_content/content/normalmap_embed_resource/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="toggled" from="VBoxContainer/extra/sections/output/section_content/content/embed/CheckBox" to="." method="_on_round_fps_toggled"]
 [connection signal="text_changed" from="VBoxContainer/extra/sections/output/section_content/content/out_filename/LineEdit" to="." method="_on_line_edit_text_changed"]
 [connection signal="value_changed" from="VBoxContainer/extra/sections/output/section_content/content/scale/SpinBox" to="." method="_on_spin_box_value_changed"]

--- a/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
@@ -183,7 +183,15 @@ func _import_for_animation_player():
 		"should_create_portable_texture": _embed_field.button_pressed,
 		"convert_to_fps": _convert_to_fps.button_pressed,
 		"convert_ms_field": _convert_ms_field.value,
-		"convert_fps_field": _convert_fps_field.value
+		"convert_fps_field": _convert_fps_field.value,
+		"normalmap_generate": _normalmap_generate_field.button_pressed,
+		"normalmap_params": {
+			"emboss_height": _normalmap_emboss_height_field.value,
+			"bump_height": _normalmap_bump_height_field.value,
+			"blur": int(_normalmap_blur_field.value),
+			"bump": int(_normalmap_bump_field.value),
+		},
+		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
 	}
 
 	animation_creator.create_animations(target_node, root.get_node(_animation_player_path), aseprite_output.content, anim_options)
@@ -216,6 +224,14 @@ func _import_static():
 	static_texture_creator.load_texture(target_node, aseprite_output.content, {
 		"slice": _slice,
 		"should_create_portable_texture": _embed_field.button_pressed,
+		"normalmap_generate": _normalmap_generate_field.button_pressed,
+		"normalmap_params": {
+			"emboss_height": _normalmap_emboss_height_field.value,
+			"bump_height": _normalmap_bump_height_field.value,
+			"blur": int(_normalmap_blur_field.value),
+			"bump": int(_normalmap_bump_field.value),
+		},
+		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
 	})
 
 	_importing = false

--- a/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
+++ b/addons/AsepriteWizard/interface/docks/sprite/sprite_inspector_dock.gd
@@ -176,6 +176,10 @@ func _import_for_animation_player():
 	file_system.scan()
 	await file_system.filesystem_changed
 
+	var normalmap_tex: Texture2D = null
+	if _normalmap_generate_field.button_pressed:
+		normalmap_tex = await _prepare_normal_texture(aseprite_output.content.sprite_sheet)
+
 	var anim_options = {
 		"keep_anim_length": _keep_length.button_pressed,
 		"cleanup_hide_unused_nodes": _cleanup_hide_unused_nodes.button_pressed,
@@ -184,14 +188,8 @@ func _import_for_animation_player():
 		"convert_to_fps": _convert_to_fps.button_pressed,
 		"convert_ms_field": _convert_ms_field.value,
 		"convert_fps_field": _convert_fps_field.value,
-		"normalmap_generate": _normalmap_generate_field.button_pressed,
-		"normalmap_params": {
-			"emboss_height": _normalmap_emboss_height_field.value,
-			"bump_height": _normalmap_bump_height_field.value,
-			"blur": int(_normalmap_blur_field.value),
-			"bump": int(_normalmap_bump_field.value),
-		},
-		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
+		"normalmap_texture": normalmap_tex,
+		"normalmap_embed_resource": _normalmap_embed_resource_field.button_pressed,
 	}
 
 	animation_creator.create_animations(target_node, root.get_node(_animation_player_path), aseprite_output.content, anim_options)
@@ -221,17 +219,15 @@ func _import_static():
 	file_system.scan()
 	await file_system.filesystem_changed
 
+	var normalmap_tex: Texture2D = null
+	if _normalmap_generate_field.button_pressed:
+		normalmap_tex = await _prepare_normal_texture(aseprite_output.content.sprite_sheet)
+
 	static_texture_creator.load_texture(target_node, aseprite_output.content, {
 		"slice": _slice,
 		"should_create_portable_texture": _embed_field.button_pressed,
-		"normalmap_generate": _normalmap_generate_field.button_pressed,
-		"normalmap_params": {
-			"emboss_height": _normalmap_emboss_height_field.value,
-			"bump_height": _normalmap_bump_height_field.value,
-			"blur": int(_normalmap_blur_field.value),
-			"bump": int(_normalmap_bump_field.value),
-		},
-		"normalmap_save_debug_png": _normalmap_save_debug_png_field.button_pressed,
+		"normalmap_texture": normalmap_tex,
+		"normalmap_embed_resource": _normalmap_embed_resource_field.button_pressed,
 	})
 
 	_importing = false

--- a/addons/AsepriteWizard/normalmap/normal_map_generator.gd
+++ b/addons/AsepriteWizard/normalmap/normal_map_generator.gd
@@ -1,0 +1,248 @@
+@tool
+extends RefCounted
+## CPU-based normal map generator.
+## Ported from godot_normalMap_generator shaders (distance.gdshader + normalmap.gdshader).
+
+const DEFAULT_PARAMS := {
+	"emboss_height": 2.0,
+	"bump_height": 8.0,
+	"blur": 2,
+	"bump": 150,
+	"invert_x": false,
+	"invert_y": false,
+	"with_emboss": true,
+	"with_distance": true,
+}
+
+
+static func generate_normal_map(source: Image, params: Dictionary = {}) -> Image:
+	var p := DEFAULT_PARAMS.duplicate()
+	p.merge(params, true)
+
+	var width := source.get_width()
+	var height := source.get_height()
+
+	# Compute distance field from alpha edges
+	var distance_field: PackedFloat32Array
+	if p.with_distance:
+		distance_field = _compute_distance_field(source, width, height)
+	else:
+		distance_field = PackedFloat32Array()
+		distance_field.resize(width * height)
+		distance_field.fill(0.0)
+
+	# Precompute grayscale for emboss
+	var grayscale: PackedFloat32Array
+	if p.with_emboss:
+		grayscale = _compute_grayscale(source, width, height)
+	else:
+		grayscale = PackedFloat32Array()
+		grayscale.resize(width * height)
+		grayscale.fill(0.0)
+
+	# Build Gaussian kernel if blur > 0
+	var kernel: PackedFloat32Array
+	var kernel_size: int = 0
+	var blur_val: int = int(p.blur)
+	if blur_val > 0:
+		kernel_size = blur_val * 2 + 1
+		kernel = _build_gaussian_kernel(blur_val)
+	else:
+		kernel = PackedFloat32Array()
+
+	var inv_x: float = -1.0 if p.invert_x else 1.0
+	var inv_y: float = -1.0 if p.invert_y else 1.0
+	var emboss_h: float = p.emboss_height
+	var bump_h: float = p.bump_height
+	var bump_val: int = maxi(int(p.bump), 1)
+	var bump_factor: float = 255.0 / float(bump_val)
+	var with_emboss: bool = p.with_emboss
+	var with_distance: bool = p.with_distance
+
+	var result := Image.create(width, height, false, Image.FORMAT_RGBA8)
+
+	for y in range(height):
+		for x in range(width):
+			var x0 := 0.0
+			var x1 := 0.0
+			var y0 := 0.0
+			var y1 := 0.0
+			var distx0 := 0.0
+			var distx1 := 0.0
+			var disty0 := 0.0
+			var disty1 := 0.0
+
+			if blur_val > 0:
+				var blur_den := 0.0
+				for j in range(-blur_val, blur_val + 1):
+					for i in range(-blur_val, blur_val + 1):
+						var ki := i + blur_val
+						var kj := j + blur_val
+						var coef: float = kernel[kj * kernel_size + ki]
+						blur_den += coef
+
+						if with_emboss:
+							x0 += _sample_grayscale(grayscale, x - 1 + i, y + j, width, height) * coef
+							x1 += _sample_grayscale(grayscale, x + 1 + i, y + j, width, height) * coef
+							y0 += _sample_grayscale(grayscale, x + i, y - 1 + j, width, height) * coef
+							y1 += _sample_grayscale(grayscale, x + i, y + 1 + j, width, height) * coef
+
+						if with_distance:
+							distx0 += _sample_field(distance_field, x - 1 + i, y + j, width, height) * coef
+							distx1 += _sample_field(distance_field, x + 1 + i, y + j, width, height) * coef
+							disty0 += _sample_field(distance_field, x + i, y - 1 + j, width, height) * coef
+							disty1 += _sample_field(distance_field, x + i, y + 1 + j, width, height) * coef
+
+				if blur_den > 0.0:
+					var inv_den := 1.0 / blur_den
+					x0 *= inv_den
+					x1 *= inv_den
+					y0 *= inv_den
+					y1 *= inv_den
+					distx0 *= inv_den
+					distx1 *= inv_den
+					disty0 *= inv_den
+					disty1 *= inv_den
+			else:
+				if with_emboss:
+					x0 = _sample_grayscale(grayscale, x - 1, y, width, height)
+					x1 = _sample_grayscale(grayscale, x + 1, y, width, height)
+					y0 = _sample_grayscale(grayscale, x, y - 1, width, height)
+					y1 = _sample_grayscale(grayscale, x, y + 1, width, height)
+
+				if with_distance:
+					distx0 = _sample_field(distance_field, x - 1, y, width, height)
+					distx1 = _sample_field(distance_field, x + 1, y, width, height)
+					disty0 = _sample_field(distance_field, x, y - 1, width, height)
+					disty1 = _sample_field(distance_field, x, y + 1, width, height)
+
+			# Apply bump factor to distance values (matching shader)
+			distx0 = minf(distx0 * bump_factor, 1.0)
+			distx1 = minf(distx1 * bump_factor, 1.0)
+			disty0 = minf(disty0 * bump_factor, 1.0)
+			disty1 = minf(disty1 * bump_factor, 1.0)
+
+			distx0 = 1.0 - absf(distx0 - 1.0)
+			distx1 = 1.0 - absf(distx1 - 1.0)
+			disty0 = 1.0 - absf(disty0 - 1.0)
+			disty1 = 1.0 - absf(disty1 - 1.0)
+
+			# Compute gradient
+			# X uses (left - right) so the normal points away from the slope, matching Godot's
+			# OpenGL normal map convention. Y uses (right - left) because Godot's import flips
+			# the green channel, which cancels the inversion.
+			var dx: float = inv_x * (x0 - x1) * 0.5
+			var dy: float = inv_y * (-y0 + y1) * 0.5
+			var bx: float = inv_x * (distx0 - distx1) * 0.5
+			var by: float = inv_y * (-disty0 + disty1) * 0.5
+
+			# Compute normals
+			var ne := Vector3(dx * emboss_h, dy * emboss_h, 1.0).normalized()
+			var nb := Vector3(bx * bump_h, by * bump_h, 1.0).normalized()
+			var normal := (ne + nb).normalized()
+
+			# Map from [-1,1] to [0,1]
+			normal = normal * 0.5 + Vector3(0.5, 0.5, 0.5)
+
+			# Preserve source alpha
+			var src_alpha: float = source.get_pixel(x, y).a
+			result.set_pixel(x, y, Color(normal.x, normal.y, normal.z, src_alpha))
+
+	return result
+
+
+static func _compute_grayscale(img: Image, w: int, h: int) -> PackedFloat32Array:
+	var data := PackedFloat32Array()
+	data.resize(w * h)
+	for y in range(h):
+		for x in range(w):
+			var c := img.get_pixel(x, y)
+			data[y * w + x] = c.r * 0.2126 + c.g * 0.7152 + c.b * 0.0722
+	return data
+
+
+static func _compute_distance_field(img: Image, w: int, h: int) -> PackedFloat32Array:
+	# Two-pass approximate distance transform (Danielsson-style).
+	# Computes normalized distance from each opaque pixel to nearest transparent edge.
+	var INF_DIST := float(w + h)
+	var dist := PackedFloat32Array()
+	dist.resize(w * h)
+
+	# Initialize: transparent pixels = 0, opaque pixels = INF
+	for y in range(h):
+		for x in range(w):
+			if img.get_pixel(x, y).a < 0.01:
+				dist[y * w + x] = 0.0
+			else:
+				dist[y * w + x] = INF_DIST
+
+	# Forward pass (top-left to bottom-right)
+	for y in range(h):
+		for x in range(w):
+			var idx := y * w + x
+			var d := dist[idx]
+			if x > 0:
+				d = minf(d, dist[idx - 1] + 1.0)
+			if y > 0:
+				d = minf(d, dist[(y - 1) * w + x] + 1.0)
+			if x > 0 and y > 0:
+				d = minf(d, dist[(y - 1) * w + x - 1] + 1.414)
+			if x < w - 1 and y > 0:
+				d = minf(d, dist[(y - 1) * w + x + 1] + 1.414)
+			dist[idx] = d
+
+	# Backward pass (bottom-right to top-left)
+	for y in range(h - 1, -1, -1):
+		for x in range(w - 1, -1, -1):
+			var idx := y * w + x
+			var d := dist[idx]
+			if x < w - 1:
+				d = minf(d, dist[idx + 1] + 1.0)
+			if y < h - 1:
+				d = minf(d, dist[(y + 1) * w + x] + 1.0)
+			if x < w - 1 and y < h - 1:
+				d = minf(d, dist[(y + 1) * w + x + 1] + 1.414)
+			if x > 0 and y < h - 1:
+				d = minf(d, dist[(y + 1) * w + x - 1] + 1.414)
+			dist[idx] = d
+
+	# Normalize to [0, 1] range by max possible distance
+	var max_dist := 0.0
+	for i in range(dist.size()):
+		if dist[i] > max_dist and dist[i] < INF_DIST:
+			max_dist = dist[i]
+
+	if max_dist > 0.0:
+		var inv_max := 1.0 / max_dist
+		for i in range(dist.size()):
+			dist[i] = minf(dist[i] * inv_max, 1.0)
+
+	return dist
+
+
+static func _build_gaussian_kernel(radius: int) -> PackedFloat32Array:
+	var size := radius * 2 + 1
+	var kernel := PackedFloat32Array()
+	kernel.resize(size * size)
+	var sigma := float(radius) / 3.0
+	var two_sigma_sq := 2.0 * sigma * sigma
+
+	for j in range(-radius, radius + 1):
+		for i in range(-radius, radius + 1):
+			var d_sq := float(i * i + j * j)
+			var val := exp(-d_sq / two_sigma_sq) / (PI * two_sigma_sq)
+			kernel[(j + radius) * size + (i + radius)] = val
+
+	return kernel
+
+
+static func _sample_grayscale(data: PackedFloat32Array, x: int, y: int, w: int, h: int) -> float:
+	if x < 0 or x >= w or y < 0 or y >= h:
+		return 0.0
+	return data[y * w + x]
+
+
+static func _sample_field(data: PackedFloat32Array, x: int, y: int, w: int, h: int) -> float:
+	if x < 0 or x >= w or y < 0 or y >= h:
+		return 0.0
+	return data[y * w + x]

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Import Aseprite files to Godot in many different ways."
 author="Vinicius Gerevini"
-version="9.8.0"
+version="9.8.0.1"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Import Aseprite files to Godot in many different ways."
 author="Vinicius Gerevini"
-version="9.8.0.1"
+version="9.9.0"
 script="plugin.gd"

--- a/addons/AsepriteWizard/plugin.cfg
+++ b/addons/AsepriteWizard/plugin.cfg
@@ -3,5 +3,5 @@
 name="Aseprite Wizard"
 description="Import Aseprite files to Godot in many different ways."
 author="Vinicius Gerevini"
-version="9.9.0"
+version="9.8.0"
 script="plugin.gd"


### PR DESCRIPTION
This adds a built-in normal map generator to the plugin, so you can go straight from an Aseprite file to a lit sprite without needing any external tools or manually authoring a normal map.

When you enable the "Generate Normal Map" option in the inspector dock, the plugin generates a normal map from the exported sprite sheet using a distance field + emboss technique (ported from existing GLSL shaders). The result is automatically wrapped in a CanvasTexture alongside the diffuse texture, so it works with Godot's 2D lighting out of the box.

You can tune four parameters to get the look you want: Emboss Height, Bump Height, Blur, and Bump intensity.

As the generation may take up to several minutes, generation runs in a background thread so the editor doesn't freeze on larger sprite sheets. A small status label appears in the dock while it's working.

