### PR TITLE
Fix incorrect cleanup for prefixed animation inside a library

### DIFF
--- a/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
+++ b/addons/AsepriteWizard/creators/animation_player/animation_creator.gd
@@ -340,6 +340,15 @@ func _relevant_track_count(target_node: Node, player: AnimationPlayer, animation
 
 
 func _animation_name_without_loop_prefix(animation_name: String) -> String:
+	var anim_tokens := animation_name.split("/")
+
+	if anim_tokens.size() == 2:
+		var library_name = anim_tokens[0]
+		animation_name = anim_tokens[1]
+		if animation_name.begins_with(_config.get_animation_loop_exception_prefix()):
+			animation_name = animation_name.substr(_config.get_animation_loop_exception_prefix().length())
+		return "%s/%s" % [library_name, animation_name]
+		
 	if animation_name.begins_with(_config.get_animation_loop_exception_prefix()):
 		return animation_name.substr(_config.get_animation_loop_exception_prefix().length())
 	return animation_name


### PR DESCRIPTION
Closes https://github.com/viniciusgerevini/godot-aseprite-wizard/issues/266

This PR updates the `_remove_unused_animations()` function to also account for prefixed animations inside a library, which is causing a bug where such animations are not imported correctly.

I considered doing a more thorough refactor to prevent future bugs, as there's duplicate logic in the act of trimming animation name in `_add_animation_frames()` and `_remove_unused_animations()`, but there are a few extra considerations on how to do this. Mainly that `_add_animation_frame` needs the library name, animation name, and whether or not it's looped, VS `_remove_unused_animations`, which only needs the full name. Returning a dictionary is one solution, but I could see some being against it due to weaker typing. In any case, I'll leave that decision up to the maintainer for now, so the PR just adds the bare minimum fix.